### PR TITLE
fix: set aws-marketplace base url as github actions secret

### DIFF
--- a/.github/actions/aws-marketplace-ecr-login/action.yml
+++ b/.github/actions/aws-marketplace-ecr-login/action.yml
@@ -12,5 +12,5 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}
     - run: |
-        aws ecr get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin $MARKETPLACE_BASE_URL/camunda
+        aws ecr get-login-password --region ${{ inputs.aws-region }} | docker login --username AWS --password-stdin ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda
       shell: bash

--- a/.github/workflows/aws-marketplace-camunda-helm-chart.yaml
+++ b/.github/workflows/aws-marketplace-camunda-helm-chart.yaml
@@ -27,7 +27,7 @@ jobs:
           aws-region: "us-east-1"
 
       - run: |
-          aws ecr get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin $MARKETPLACE_BASE_URL
+          aws ecr get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}
 
       - name: add repo
         run: helm repo add camunda "https://helm.camunda.io"

--- a/.github/workflows/aws-marketplace-connectors.yaml
+++ b/.github/workflows/aws-marketplace-connectors.yaml
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: camunda/connectors-bundle:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/connectors-bundle:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/connectors-bundle:${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-elasticsearch.yaml
+++ b/.github/workflows/aws-marketplace-elasticsearch.yaml
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: bitnami/elasticsearch:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/elasticsearch:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/elasticsearch:${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-identity.yaml
+++ b/.github/workflows/aws-marketplace-identity.yaml
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: camunda/identity:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/identity:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/identity:${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-keycloak.yaml
+++ b/.github/workflows/aws-marketplace-keycloak.yaml
@@ -26,5 +26,5 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: bitnami/keycloak:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/keycloak:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/keycloak:${{ inputs.imageTag }}
 

--- a/.github/workflows/aws-marketplace-license-manager.yaml
+++ b/.github/workflows/aws-marketplace-license-manager.yaml
@@ -23,11 +23,11 @@ jobs:
           aws-region: "us-east-1"
 
       - name: Build the docker image
-        run: docker build -f aws-marketplace/license-manager/Dockerfile -t $MARKETPLACE_BASE_URL/camunda/camunda8/license-manager:$IMAGE_TAG license-manager
+        run: docker build -f aws-marketplace/license-manager/Dockerfile -t ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/license-manager:$IMAGE_TAG license-manager
         env:
           IMAGE_TAG: ${{ inputs.imageTag }}
 
       - name: Push the docker image
-        run: docker push $MARKETPLACE_BASE_URL/camunda/camunda8/license-manager:$IMAGE_TAG
+        run: docker push ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/license-manager:$IMAGE_TAG
         env:
           IMAGE_TAG: ${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-modeler.yaml
+++ b/.github/workflows/aws-marketplace-modeler.yaml
@@ -32,16 +32,16 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: registry.camunda.cloud/web-modeler-ee/modeler-restapi:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/modeler-restapi:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/modeler-restapi:${{ inputs.imageTag }}
 
       - name: web modeler webapp
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: registry.camunda.cloud/web-modeler-ee/modeler-webapp:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/modeler-webapp:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/modeler-webapp:${{ inputs.imageTag }}
 
       - name: web modeler websockets
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: registry.camunda.cloud/web-modeler-ee/modeler-websockets:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/modeler-websockets:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/modeler-websockets:${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-operate.yaml
+++ b/.github/workflows/aws-marketplace-operate.yaml
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: camunda/operate:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/operate:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/operate:${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-optimize.yaml
+++ b/.github/workflows/aws-marketplace-optimize.yaml
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: camunda/optimize:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/optimize:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/optimize:${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-postgresql.yaml
+++ b/.github/workflows/aws-marketplace-postgresql.yaml
@@ -25,4 +25,4 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: bitnami/postgresql:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/postgresql:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/postgresql:${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-tasklist.yaml
+++ b/.github/workflows/aws-marketplace-tasklist.yaml
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: camunda/tasklist:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/tasklist:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/tasklist:${{ inputs.imageTag }}

--- a/.github/workflows/aws-marketplace-zeebe.yaml
+++ b/.github/workflows/aws-marketplace-zeebe.yaml
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/aws-marketplace-ecr-mirror
         with:
           from: camunda/zeebe:${{ inputs.imageTag }}
-          to: ${{ env.MARKETPLACE_BASE_URL }}/camunda/camunda8/zeebe:${{ inputs.imageTag }}
+          to: ${{ secrets.DISTRO_CI_AWS_MPLACE_BASE_URL }}/camunda/camunda8/zeebe:${{ inputs.imageTag }}

--- a/aws-marketplace/mirror.sh
+++ b/aws-marketplace/mirror.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CAMUNDA_VERSION=10.4.2
+export CAMUNDA_VERSION=10.4.7
 
 helm repo update
 
@@ -33,6 +33,7 @@ export ELASTICSEARCH_VERSION="$(cat chart_images | grep elasticsearch | sed 's/[
 export POSTGRESQL_VERSION="$(cat chart_images | grep postgresql | sed 's/[^:]*://')"
 export KEYCLOAK_VERSION="$(cat chart_images | grep keycloak | sed 's/[^:]*://')"
 export CONSOLE_VERSION="$(cat chart_images | grep console | sed 's/[^:]*://')"
+export LICENSE_MANAGER_VERSION="0.0.1"
 
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 709825985650.dkr.ecr.us-east-1.amazonaws.com
 
@@ -102,4 +103,10 @@ docker manifest inspect 709825985650.dkr.ecr.us-east-1.amazonaws.com/camunda/cam
 helm_image_exists=$?
 if [[ "$helm_image_exists" != "0" ]]; then
     gh workflow run aws-marketplace-camunda-helm-chart.yaml -f imageTag=$CAMUNDA_VERSION -f awsImageTag=$CAMUNDA_VERSION
+fi
+
+docker manifest inspect 709825985650.dkr.ecr.us-east-1.amazonaws.com/camunda/camunda8/license-manager:$LICENSE_MANAGER_VERSION > /dev/null
+license_manager_exists=$?
+if [[ "$license_manager_exists" != "0" ]]; then
+    gh workflow run aws-marketplace-license-manager.yaml -f imageTag=$LICENSE_MANAGER_VERSION -f awsImageTag=$LICENSE_MANAGER_VERSION
 fi


### PR DESCRIPTION
The aws marketplace CI failed recently due to the base url not being set. This tricked our CI into thinking that we were trying to authenticate into the default dockerhub docker registry instead of the AWS Marketplace ECR registry.