### PR TITLE
cd: release docker compose as an artifact

### DIFF
--- a/.github/actions/generate-versions-matrix/action.yml
+++ b/.github/actions/generate-versions-matrix/action.yml
@@ -7,6 +7,8 @@ inputs:
     required: true
 
 outputs:
+  # NOTE: The logic is reversed here (get unchanged files instead of the changed ones),
+  # to avoid creating GHA skipped jobs. This twist is due to how GHA works.
   unchanged:
     description: JSON matrix of unchanged versions which will be used as and input for GHA workflow matrix exclude.
     value: ${{ steps.get-versions.outputs.matrix-unchanged }}
@@ -26,6 +28,7 @@ runs:
         ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         UNCHANGED_VERSIONS_TMP_FILE: unchanged_versions.txt
       run: |
+        env
         echo "Setting matrix based on changed files"
         echo "Changed files:"
         printf "%s\n" ${ALL_CHANGED_FILES}

--- a/.github/actions/generate-versions-matrix/action.yml
+++ b/.github/actions/generate-versions-matrix/action.yml
@@ -7,11 +7,14 @@ inputs:
     required: true
 
 outputs:
-  # NOTE: The logic is reversed here (get unchanged files instead of the changed ones),
-  # to avoid creating GHA skipped jobs. This twist is due to how GHA works.
+  # NOTE: To avoid GHA creating skipped matrix jobs, the logic is reversed here.
+  # So we get unchanged files instead of the changed ones. This twist is due to how GHA works.
   unchanged:
     description: JSON matrix of unchanged versions which will be used as and input for GHA workflow matrix exclude.
     value: ${{ steps.get-versions.outputs.matrix-unchanged }}
+  should-run:
+    description: JSON matrix of changed versions (used to avoid running empty matrix).
+    value: ${{ steps.get-versions.outputs.should-run }}
 
 runs:
   using: composite
@@ -27,16 +30,18 @@ runs:
       env:
         ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         UNCHANGED_VERSIONS_TMP_FILE: unchanged_versions.txt
+        CHANGED_VERSIONS_TMP_FILE: changed_versions.txt
       run: |
-        env
         echo "Setting matrix based on changed files"
         echo "Changed files:"
         printf "%s\n" ${ALL_CHANGED_FILES}
+        touch ${CHANGED_VERSIONS_TMP_FILE}
         touch ${UNCHANGED_VERSIONS_TMP_FILE}
 
         ls -d ${{ inputs.versions-path }} | while read version_dir; do
           if [[ $(echo ${ALL_CHANGED_FILES} | grep "${version_dir}") ]]; then
-            continue
+            echo "Camunda version: ${version_dir}"
+            echo "${version_dir}" >> ${CHANGED_VERSIONS_TMP_FILE};
           else
             camunda_version="$(echo ${version_dir} | rev | cut -d '-' -f 1 | rev)";
             echo "Camunda version: ${camunda_version}"
@@ -44,6 +49,10 @@ runs:
           fi
         done
         # NOTE: The keys "versions" and "camunda-version" are hard-coded and should be used in the workflow matrix.
+        # Unchanged.
         matrix_unchanged="$(cat ${UNCHANGED_VERSIONS_TMP_FILE} |
           jq -s -c -R 'split("\n") | .[:-1] | map({"versions": {"camunda-version": .}})')"
         echo "matrix-unchanged=${matrix_unchanged}" | tee -a $GITHUB_OUTPUT
+        # Changed.
+        should_run="$([[ $(stat --printf="%s" ${CHANGED_VERSIONS_TMP_FILE}) -gt 0 ]] && echo "true" || echo "false")"
+        echo "should-run=${should_run}" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/docker-compose-release-template.yaml
+++ b/.github/workflows/docker-compose-release-template.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          ref: ${{ inputs.git-ref }}
+          ref: ${{ github.ref }}
 
       #
       # Artifacts.

--- a/.github/workflows/docker-compose-release-template.yaml
+++ b/.github/workflows/docker-compose-release-template.yaml
@@ -1,0 +1,102 @@
+# NOTE: Camunda Docker Compose release is a rolling release.
+# So it's always 1 artifact per Camunda minor version.
+name: "Docker Compose | Release - Template"
+
+on:
+  workflow_call:
+    inputs:
+      camunda-version:
+        description: Camunda minor version in format x.y or alpha.
+        required: true
+        type: string
+
+env:
+  DOCKER_COMPOSE_NAME: docker-compose-${{ inputs.camunda-version }}
+  DOCKER_COMPOSE_WORKING_DIRECTORY: docker-compose/versions/camunda-${{ inputs.camunda-version }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      #
+      # Init.
+      - name: ℹ️ Print workflow inputs ℹ️
+        env:
+          GITHUB_CONTEXT: ${{ toJson(inputs) }}
+        run: |
+          echo "Workflow Inputs:"
+          echo "${GITHUB_CONTEXT}"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ inputs.git-ref }}
+
+      #
+      # Artifacts.
+      - name: Create release artifact
+        run: |
+          tar -czf ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
+            -C ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }} .
+
+      #
+      # Security signature.
+      - name: Install Cosign CLI
+        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+      - name: Sign Helm chart with Cosign
+        run: |
+          cosign sign-blob -y ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
+            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
+      - name: Verify signed Helm chart with Cosign
+        run: |
+          cosign verify-blob ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
+            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/docker-compose-release-template.yaml@${{ github.ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+      #
+      # Release
+      # TODO: Use gomplate to generate the Docker Compose release notes.
+      - name: Create release notes
+        run: |
+          grep _VERSION ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }}/.env > VERSIONS.txt
+          cat << EOF > RELEASE-NOTES.md
+          $(cat ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }}/README.md) 
+          ## Versions
+          $(printf -- "- %s\n" $(cat VERSIONS.txt))
+          ## Verification
+          To verify the integrity of the artifact using [Cosign](https://docs.sigstore.dev/signing/quickstart/):
+          \`\`\`shell
+          # Download Docker Compose artifact.
+          curl -LO https://github.com/${{ github.repository }}/releases/download/${{ env.DOCKER_COMPOSE_NAME }}/${{ env.DOCKER_COMPOSE_NAME }}.tgz
+          # Download Docker Compose Cosign bundle.
+          curl -LO https://github.com/${{ github.repository }}/releases/download/${{ env.DOCKER_COMPOSE_NAME }}/${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
+          # Verify with cosign.
+          cosign verify-blob ${{ env.DOCKER_COMPOSE_NAME }}.tgz \\
+            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle \\
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/docker-compose-release-template.yaml@${{ github.ref }}"
+          \`\`\`
+          ## Notes
+          - **Release strategy:** Camunda Docker Compose release is a rolling release. Hence, it's always 1 artifact per Camunda minor version.
+          - **Latest update:** $(date)
+          EOF
+      - name: Create git tag
+        run: |
+          git tag ${{ env.DOCKER_COMPOSE_NAME }}
+      - name: Release on GitHub
+        id: gh-release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
+        with:
+          name: ${{ env.DOCKER_COMPOSE_NAME }}
+          tag_name: ${{ env.DOCKER_COMPOSE_NAME }}
+          body_path: RELEASE-NOTES.md
+          files: |
+            ${{ env.DOCKER_COMPOSE_NAME }}.tgz
+            ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
+      - name: Add release URL to workflow summary
+        run: |
+          echo "⭐ Release URL: ${{steps.gh-release.outputs.url}}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-compose-release.yaml
+++ b/.github/workflows/docker-compose-release.yaml
@@ -30,11 +30,13 @@ jobs:
         with:
           versions-path: "docker-compose/versions/camunda-*"
     outputs:
+      should-run: ${{ steps.generate-versions-matrix.outputs.should-run }}
       unchanged-versions: ${{ steps.generate-versions-matrix.outputs.unchanged }}
 
   exec:
     needs: [init]
-    name: ${{ matrix.versions.name }}
+    if: ${{ needs.init.outputs.should-run == 'true' }}
+    name: ${{ matrix.versions.name || 'Skipped' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-compose-release.yaml
+++ b/.github/workflows/docker-compose-release.yaml
@@ -3,110 +3,54 @@
 name: "Docker Compose | Release"
 
 on:
-  workflow_dispatch:
-    inputs:
-      camunda-version:
-        description: Camunda minor version in format x.y
-        required: true
-        type: string
-      release-tag:
-        description: |
-          The tag name of the released Docker Compose.
-          By Default, it will use the platform version.
-        type: string
-      git-ref:
-        description: Git ref that will be used to release.
-        default: main
-        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - docker-compose/versions/**
+  pull_request:
+    paths:
+      - .github/workflows/docker-compose-release-template.yaml
+      - .github/workflows/docker-compose-release.yaml
+      - docker-compose/versions/**
 
-env:
-  GIT_REF: ${{ inputs.git-ref }}
-  DOCKER_COMPOSE_NAME: docker-compose-${{ inputs.camunda-version }}
-  DOCKER_COMPOSE_WORKING_DIRECTORY: docker-compose/versions/camunda-${{ inputs.camunda-version }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
-  release:
-    name: Release
+  init:
+    name: Generate version matrix
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
     steps:
-      #
-      # Init.
-      - name: ℹ️ Print workflow inputs ℹ️
-        env:
-          GITHUB_CONTEXT: ${{ toJson(inputs) }}
-        run: |
-          echo "Workflow Inputs:"
-          echo "${GITHUB_CONTEXT}"
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Generate versions
+        id: generate-versions-matrix
+        uses: ./.github/actions/generate-versions-matrix
         with:
-          ref: ${{ inputs.git-ref }}
+          versions-path: "docker-compose/versions/camunda-*"
+    outputs:
+      unchanged-versions: ${{ steps.generate-versions-matrix.outputs.unchanged }}
 
-      #
-      # Artifacts.
-      - name: Create release artifact
-        run: |
-          tar -czf ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
-            -C ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }} .
-
-      #
-      # Security signature.
-      - name: Install Cosign CLI
-        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
-      - name: Sign Helm chart with Cosign
-        run: |
-          cosign sign-blob -y ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
-            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
-      - name: Verify signed Helm chart with Cosign
-        run: |
-          cosign verify-blob ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
-            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle \
-            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/docker-compose-release.yaml@refs/heads/${{ env.GIT_REF }}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-
-      #
-      # Release
-      # TODO: Use gomplate to generate the Docker Compose release notes.
-      - name: Create release notes
-        run: |
-          grep _VERSION ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }}/.env > VERSIONS.txt
-          cat << EOF > RELEASE-NOTES.md
-          $(cat ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }}/README.md) 
-          ## Versions
-          $(printf -- "- %s\n" $(cat VERSIONS.txt))
-          ## Verification
-          To verify the integrity of the artifact using [Cosign](https://docs.sigstore.dev/signing/quickstart/):
-          \`\`\`shell
-          # Download Docker Compose artifact.
-          curl -LO https://github.com/${{ github.repository }}/releases/download/${{ env.DOCKER_COMPOSE_NAME }}/${{ env.DOCKER_COMPOSE_NAME }}.tgz
-          # Download Docker Compose Cosign bundle.
-          curl -LO https://github.com/${{ github.repository }}/releases/download/${{ env.DOCKER_COMPOSE_NAME }}/${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
-          # Verify with cosign.
-          cosign verify-blob ${{ env.DOCKER_COMPOSE_NAME }}.tgz \\
-            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle \\
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\
-            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/docker-compose-release.yaml@refs/heads/${{ env.GIT_REF }}"
-          \`\`\`
-          ## Notes
-          - **Release strategy:** Camunda Docker Compose release is a rolling release. Hence, it's always 1 artifact per Camunda minor version.
-          - **Latest update:** $(date)
-          EOF
-      - name: Create git tag
-        run: |
-          git tag ${{ env.DOCKER_COMPOSE_NAME }}
-      - name: Release on GitHub
-        id: gh-release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
-        with:
-          name: ${{ env.DOCKER_COMPOSE_NAME }}
-          tag_name: ${{ env.DOCKER_COMPOSE_NAME }}
-          body_path: RELEASE-NOTES.md
-          files: |
-            ${{ env.DOCKER_COMPOSE_NAME }}.tgz
-            ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
-      - name: Add release URL to workflow summary
-        run: |
-          echo "⭐ Release URL: ${{steps.gh-release.outputs.url}}" >> $GITHUB_STEP_SUMMARY
+  exec:
+    needs: [init]
+    name: ${{ matrix.versions.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        versions:
+          - name: Camunda 8.3
+            camunda-version: 8.3
+          - name: Camunda 8.4
+            camunda-version: 8.5
+          - name: Camunda 8.5
+            camunda-version: 8.5
+          - name: Camunda 8.6
+            camunda-version: 8.6
+          - name: Camunda Alpha
+            camunda-version: alpha
+        exclude: ${{ fromJson(needs.init.outputs.unchanged-versions) }}
+    uses: ./.github/workflows/docker-compose-release-template.yaml
+    secrets: inherit
+    with:
+      camunda-version: ${{ matrix.versions.camunda-version }}

--- a/.github/workflows/docker-compose-release.yaml
+++ b/.github/workflows/docker-compose-release.yaml
@@ -1,0 +1,112 @@
+# NOTE: Camunda Docker Compose release is a rolling release.
+# So it's always 1 artifact per Camunda minor version.
+name: "Docker Compose | Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      camunda-version:
+        description: Camunda minor version in format x.y
+        required: true
+        type: string
+      release-tag:
+        description: |
+          The tag name of the released Docker Compose.
+          By Default, it will use the platform version.
+        type: string
+      git-ref:
+        description: Git ref that will be used to release.
+        default: main
+        type: string
+
+env:
+  GIT_REF: ${{ inputs.git-ref }}
+  DOCKER_COMPOSE_NAME: docker-compose-${{ inputs.camunda-version }}
+  DOCKER_COMPOSE_WORKING_DIRECTORY: docker-compose/versions/camunda-${{ inputs.camunda-version }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      #
+      # Init.
+      - name: ℹ️ Print workflow inputs ℹ️
+        env:
+          GITHUB_CONTEXT: ${{ toJson(inputs) }}
+        run: |
+          echo "Workflow Inputs:"
+          echo "${GITHUB_CONTEXT}"
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ inputs.git-ref }}
+
+      #
+      # Artifacts.
+      - name: Create release artifact
+        run: |
+          tar -czf ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
+            -C ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }} .
+
+      #
+      # Security signature.
+      - name: Install Cosign CLI
+        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+      - name: Sign Helm chart with Cosign
+        run: |
+          cosign sign-blob -y ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
+            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
+      - name: Verify signed Helm chart with Cosign
+        run: |
+          cosign verify-blob ${{ env.DOCKER_COMPOSE_NAME }}.tgz \
+            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/docker-compose-release.yaml@refs/heads/${{ env.GIT_REF }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+      #
+      # Release
+      # TODO: Use gomplate to generate the Docker Compose release notes.
+      - name: Create release notes
+        run: |
+          grep _VERSION ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }}/.env > VERSIONS.txt
+          cat << EOF > RELEASE-NOTES.md
+          $(cat ${{ env.DOCKER_COMPOSE_WORKING_DIRECTORY }}/README.md) 
+          ## Versions
+          $(printf -- "- %s\n" $(cat VERSIONS.txt))
+          ## Verification
+          To verify the integrity of the artifact using [Cosign](https://docs.sigstore.dev/signing/quickstart/):
+          \`\`\`shell
+          # Download Docker Compose artifact.
+          curl -LO https://github.com/${{ github.repository }}/releases/download/${{ env.DOCKER_COMPOSE_NAME }}/${{ env.DOCKER_COMPOSE_NAME }}.tgz
+          # Download Docker Compose Cosign bundle.
+          curl -LO https://github.com/${{ github.repository }}/releases/download/${{ env.DOCKER_COMPOSE_NAME }}/${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
+          # Verify with cosign.
+          cosign verify-blob ${{ env.DOCKER_COMPOSE_NAME }}.tgz \\
+            --bundle ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle \\
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/docker-compose-release.yaml@refs/heads/${{ env.GIT_REF }}"
+          \`\`\`
+          ## Notes
+          - **Release strategy:** Camunda Docker Compose release is a rolling release. Hence, it's always 1 artifact per Camunda minor version.
+          - **Latest update:** $(date)
+          EOF
+      - name: Create git tag
+        run: |
+          git tag ${{ env.DOCKER_COMPOSE_NAME }}
+      - name: Release on GitHub
+        id: gh-release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
+        with:
+          name: ${{ env.DOCKER_COMPOSE_NAME }}
+          tag_name: ${{ env.DOCKER_COMPOSE_NAME }}
+          body_path: RELEASE-NOTES.md
+          files: |
+            ${{ env.DOCKER_COMPOSE_NAME }}.tgz
+            ${{ env.DOCKER_COMPOSE_NAME }}.cosign.bundle
+      - name: Add release URL to workflow summary
+        run: |
+          echo "⭐ Release URL: ${{steps.gh-release.outputs.url}}" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > This GitHub repository is mainly for development, don't use it directly to deploy Camunda. End users should use the [official documentation](https://docs.camunda.io/docs/self-managed/about-self-managed/).
 
-A mono repo for Camunda 8 Self-Managed Distributions.
+Camunda 8 Self-Managed Distributions (setup, deploy, etc.) mono repo for [Camunda 8 applications](https://github.com/camunda/camunda).
 
 ## Distributions
 


### PR DESCRIPTION
Part of: https://github.com/camunda/distribution/issues/287

As we move away from cloning the repo, all distributions should be released as artifacts.

Camunda Docker Compose release is a rolling release, so it's always 1 artifact per Camunda minor version (no patch versions).