### PR TITLE
refactor(docker-compose): use a separate image for each component

### DIFF
--- a/docker-compose/versions/camunda-8.6/.env
+++ b/docker-compose/versions/camunda-8.6/.env
@@ -2,7 +2,13 @@
 # renovate: datasource=docker depName=camunda/connectors-bundle
 CAMUNDA_CONNECTORS_VERSION=8.6.6
 # renovate: datasource=docker depName=camunda/zeebe
-CAMUNDA_PLATFORM_VERSION=8.6.7
+CAMUNDA_ZEEBE_VERSION=8.6.7
+# renovate: datasource=docker depName=camunda/identity
+CAMUNDA_IDENTITY_VERSION=8.6.7
+# renovate: datasource=docker depName=camunda/operate
+CAMUNDA_OPERATE_VERSION=8.6.7
+# renovate: datasource=docker depName=camunda/tasklist
+CAMUNDA_TASKLIST_VERSION=8.6.7
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.6.4
 # renovate: datasource=docker depName=camunda/web-modeler-restapi

--- a/docker-compose/versions/camunda-8.6/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-core.yaml
@@ -12,7 +12,7 @@
 services:
 
   zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
-    image: camunda/zeebe:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/zeebe:${CAMUNDA_ZEEBE_VERSION}
     container_name: zeebe
     ports:
       - "26500:26500"
@@ -42,7 +42,7 @@ services:
       - elasticsearch
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
-    image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
     container_name: operate
     ports:
       - "8081:8080"
@@ -66,7 +66,7 @@ services:
       - elasticsearch
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
-    image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
     container_name: tasklist
     ports:
       - "8082:8080"

--- a/docker-compose/versions/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose.yaml
@@ -12,7 +12,7 @@
 services:
 
   zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
-    image: camunda/zeebe:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/zeebe:${CAMUNDA_ZEEBE_VERSION}
     container_name: zeebe
     ports:
       - "26500:26500"
@@ -51,7 +51,7 @@ services:
       - orchestration
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
-    image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
     container_name: operate
     ports:
       - "8081:8080"
@@ -98,7 +98,7 @@ services:
       - orchestration
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
-    image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
     container_name: tasklist
     ports:
       - "8082:8080"
@@ -229,7 +229,7 @@ services:
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     container_name: identity
-    image: camunda/identity:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/identity:${CAMUNDA_IDENTITY_VERSION}
     ports:
       - "8084:8084"
     environment: # https://docs.camunda.io/docs/self-managed/identity/deployment/configuration-variables/
@@ -460,7 +460,7 @@ services:
       RESTAPI_MAIL_FROM_ADDRESS: "noreply@example.com"
       CAMUNDA_MODELER_CLUSTERS_0_ID: "local-zeebe"
       CAMUNDA_MODELER_CLUSTERS_0_NAME: "Local Zeebe instance"
-      CAMUNDA_MODELER_CLUSTERS_0_VERSION: ${CAMUNDA_PLATFORM_VERSION}
+      CAMUNDA_MODELER_CLUSTERS_0_VERSION: ${CAMUNDA_ZEEBE_VERSION}
       CAMUNDA_MODELER_CLUSTERS_0_URL_ZEEBE_GRPC: grpc://zeebe:26500
       CAMUNDA_MODELER_CLUSTERS_0_URL_ZEEBE_REST: http://zeebe:8080
       CAMUNDA_MODELER_CLUSTERS_0_URL_OPERATE: http://operate:8080

--- a/docker-compose/versions/camunda-alpha/.env
+++ b/docker-compose/versions/camunda-alpha/.env
@@ -2,7 +2,13 @@
 # renovate: datasource=docker depName=camunda/connectors-bundle
 CAMUNDA_CONNECTORS_VERSION=8.6.6
 # renovate: datasource=docker depName=camunda/zeebe
-CAMUNDA_PLATFORM_VERSION=8.6.7
+CAMUNDA_ZEEBE_VERSION=8.6.7
+# renovate: datasource=docker depName=camunda/identity
+CAMUNDA_IDENTITY_VERSION=8.6.7
+# renovate: datasource=docker depName=camunda/operate
+CAMUNDA_OPERATE_VERSION=8.6.7
+# renovate: datasource=docker depName=camunda/tasklist
+CAMUNDA_TASKLIST_VERSION=8.6.7
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.6.4
 # renovate: datasource=docker depName=camunda/web-modeler-restapi

--- a/docker-compose/versions/camunda-alpha/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-alpha/docker-compose-core.yaml
@@ -12,7 +12,7 @@
 services:
 
   zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
-    image: camunda/zeebe:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/zeebe:${CAMUNDA_ZEEBE_VERSION}
     container_name: zeebe
     ports:
       - "26500:26500"
@@ -42,7 +42,7 @@ services:
       - elasticsearch
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
-    image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
     container_name: operate
     ports:
       - "8081:8080"
@@ -66,7 +66,7 @@ services:
       - elasticsearch
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
-    image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
     container_name: tasklist
     ports:
       - "8082:8080"

--- a/docker-compose/versions/camunda-alpha/docker-compose.yaml
+++ b/docker-compose/versions/camunda-alpha/docker-compose.yaml
@@ -12,7 +12,7 @@
 services:
 
   zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
-    image: camunda/zeebe:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/zeebe:${CAMUNDA_ZEEBE_VERSION}
     container_name: zeebe
     ports:
       - "26500:26500"
@@ -51,7 +51,7 @@ services:
       - orchestration
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
-    image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
     container_name: operate
     ports:
       - "8081:8080"
@@ -98,7 +98,7 @@ services:
       - orchestration
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
-    image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
     container_name: tasklist
     ports:
       - "8082:8080"
@@ -229,7 +229,7 @@ services:
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     container_name: identity
-    image: camunda/identity:${CAMUNDA_PLATFORM_VERSION}
+    image: camunda/identity:${CAMUNDA_IDENTITY_VERSION}
     ports:
       - "8084:8084"
     environment: # https://docs.camunda.io/docs/self-managed/identity/deployment/configuration-variables/
@@ -460,7 +460,7 @@ services:
       RESTAPI_MAIL_FROM_ADDRESS: "noreply@example.com"
       CAMUNDA_MODELER_CLUSTERS_0_ID: "local-zeebe"
       CAMUNDA_MODELER_CLUSTERS_0_NAME: "Local Zeebe instance"
-      CAMUNDA_MODELER_CLUSTERS_0_VERSION: ${CAMUNDA_PLATFORM_VERSION}
+      CAMUNDA_MODELER_CLUSTERS_0_VERSION: ${CAMUNDA_ZEEBE_VERSION}
       CAMUNDA_MODELER_CLUSTERS_0_URL_ZEEBE_GRPC: grpc://zeebe:26500
       CAMUNDA_MODELER_CLUSTERS_0_URL_ZEEBE_REST: http://zeebe:8080
       CAMUNDA_MODELER_CLUSTERS_0_URL_OPERATE: http://operate:8080


### PR DESCRIPTION
For Camunda 8.6 and 8.7, we still use a separate image/version for each component.