### PR TITLE
chore: ignoring rc versions for renovate updates as latest

### DIFF
--- a/.github/config/renovatebot/renovate-docker-compose.json5
+++ b/.github/config/renovatebot/renovate-docker-compose.json5
@@ -32,30 +32,45 @@
       addLabels: ["version/8.3", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.3/**"],
       matchUpdateTypes: ["patch"],
+      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
+      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
+      "versioning": "semver"
     },
     {
       groupName: "camunda-docker-compose-8.4",
       addLabels: ["version/8.4", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.4/**"],
       matchUpdateTypes: ["patch"],
+      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
+      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
+      "versioning": "semver"
     },
     {
       groupName: "camunda-docker-compose-8.5",
       addLabels: ["version/8.5", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.5/**"],
       matchUpdateTypes: ["patch"],
+      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
+      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
+      "versioning": "semver"
     },
     {
       groupName: "camunda-docker-compose-8.6",
       addLabels: ["version/8.6", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.6/**"],
       matchUpdateTypes: ["patch"],
+      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
+      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
+      "versioning": "semver"
     },
     {
       groupName: "camunda-docker-compose-alpha",
       addLabels: ["version/8.7", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-alpha/**"],
       matchUpdateTypes: ["patch", "minor"],
+      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
+      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
+      "versioning": "semver"
     },
     // End of minor cycle chores.
 

--- a/.github/config/renovatebot/renovate-docker-compose.json5
+++ b/.github/config/renovatebot/renovate-docker-compose.json5
@@ -32,45 +32,40 @@
       addLabels: ["version/8.3", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.3/**"],
       matchUpdateTypes: ["patch"],
-      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
-      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
-      "versioning": "semver"
+      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
+      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     {
       groupName: "camunda-docker-compose-8.4",
       addLabels: ["version/8.4", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.4/**"],
       matchUpdateTypes: ["patch"],
-      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
-      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
-      "versioning": "semver"
+      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
+      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     {
       groupName: "camunda-docker-compose-8.5",
       addLabels: ["version/8.5", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.5/**"],
       matchUpdateTypes: ["patch"],
-      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
-      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
-      "versioning": "semver"
+      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
+      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     {
       groupName: "camunda-docker-compose-8.6",
       addLabels: ["version/8.6", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.6/**"],
       matchUpdateTypes: ["patch"],
-      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
-      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
-      "versioning": "semver"
+      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
+      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     {
       groupName: "camunda-docker-compose-alpha",
       addLabels: ["version/8.7", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-alpha/**"],
       matchUpdateTypes: ["patch", "minor"],
-      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3 which is not the case.
-      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
-      "versioning": "semver"
+      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
+      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     // End of minor cycle chores.
 

--- a/.github/config/renovatebot/renovate-docker-compose.json5
+++ b/.github/config/renovatebot/renovate-docker-compose.json5
@@ -32,40 +32,32 @@
       addLabels: ["version/8.3", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.3/**"],
       matchUpdateTypes: ["patch"],
-      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
-      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     {
       groupName: "camunda-docker-compose-8.4",
       addLabels: ["version/8.4", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.4/**"],
       matchUpdateTypes: ["patch"],
-      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
-      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     {
       groupName: "camunda-docker-compose-8.5",
       addLabels: ["version/8.5", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.5/**"],
       matchUpdateTypes: ["patch"],
-      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
-      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     {
       groupName: "camunda-docker-compose-8.6",
       addLabels: ["version/8.6", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-8.6/**"],
       matchUpdateTypes: ["patch"],
-      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
-      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
     },
     {
       groupName: "camunda-docker-compose-alpha",
       addLabels: ["version/8.7", "deps/docker-compose"],
       matchFileNames: ["docker-compose/versions/camunda-alpha/**"],
-      matchUpdateTypes: ["patch", "minor"],
-      // Allows any versions that matches stable and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3).
-      allowedVersions: "^\\d+\\.\\d+\\.\\d+(-alpha\\..*)?$"
+      // Allows only patch and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3, but no 8.7.0-alpha3-rc1).
+      allowedVersions: "^8\\.7\\.\\d+(-alpha[0-9]*)?$"
+
     },
     // End of minor cycle chores.
 


### PR DESCRIPTION
The current renovate config is updating the latest alpha releases with rc releases. This is wrong as the alpha should be latest.

Inspired by the [renovate config in the HCs](https://github.com/camunda/camunda-platform-helm/blob/main/.github/renovate.json5#L254C7-L257C29), this should fix auto-generated PRs like this: https://github.com/camunda/camunda-self-managed/pull/73

