### PR TITLE
Add demo user to admin role by default

### DIFF
--- a/docker-compose/versions/camunda-8.8/.core/application.yaml
+++ b/docker-compose/versions/camunda-8.8/.core/application.yaml
@@ -70,7 +70,7 @@ camunda:
 
   security:
     authentication:
-      mode: "none"
+      method: "basic"
       unprotectedApi: true
     authorizations:
       enabled: false


### PR DESCRIPTION
The default demo user doesn't get assigned to the admin role. Without this the user will have no permissions. By adding this config option the user is automatically assigned to the role.