### PR TITLE
fix(8.7): docker compose envvar mismatch

### DIFF
--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -165,7 +165,7 @@ services:
       # Zeebe connection
       - CAMUNDA_CLIENT_ZEEBE_RESTADDRESS=http://zeebe:8080
       - CAMUNDA_CLIENT_ZEEBE_GRPCADDRESS=http://zeebe:26500
-      - CAMUNDA_CLIENT_AUTH_TOKENURL=http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+      - CAMUNDA_CLIENT_AUTH_ISSUER=http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/token
       - CAMUNDA_CLIENT_AUTH_CLIENTID=${ZEEBE_CLIENT_ID}
       - CAMUNDA_CLIENT_AUTH_CLIENTSECRET=${ZEEBE_CLIENT_SECRET}
       - CAMUNDA_CLIENT_AUTH_CREDENTIALSCACHEPATH=/tmp/zeebe_auth_cache


### PR DESCRIPTION
Closes: https://github.com/camunda/camunda-distributions/issues/182

CAMUNDA_CLIENT_AUTH_TOKENURL is used in the docker-compose.yaml for version 8.7, even though that value should only be used from 8.8 according to Connectors documentation

Reference: https://docs.camunda.io/docs/self-managed/connectors-deployment/connectors-configuration/