### PR TITLE
fix(connectors): add client mode to 8.7 and 8.8

### DIFF
--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -163,6 +163,7 @@ services:
       - "8085:8080"
     environment:
       # Zeebe connection
+      - CAMUNDA_CLIENT_MODE=self-managed
       - CAMUNDA_CLIENT_ZEEBE_RESTADDRESS=http://zeebe:8080
       - CAMUNDA_CLIENT_ZEEBE_GRPCADDRESS=http://zeebe:26500
       - CAMUNDA_CLIENT_AUTH_ISSUER=http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/token

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -60,6 +60,7 @@ services:
       - "8085:8080"
     environment:
       # Zeebe connection
+      - CAMUNDA_CLIENT_MODE=self-managed
       - CAMUNDA_CLIENT_RESTADDRESS=http://zeebe:8080
       - CAMUNDA_CLIENT_GRPCADDRESS=http://zeebe:26500
       - CAMUNDA_CLIENT_AUTH_METHOD=oidc


### PR DESCRIPTION
This PR adds missing `CAMUNDA_CLIENT_MODE` variable to the connectors config in 8.7 and 8.8.