### PR TITLE
fix: align ports, changes connectors from 8085 to 8086

### DIFF
--- a/docker-compose/versions/camunda-8.8/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-core.yaml
@@ -47,7 +47,7 @@ services:
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
     container_name: connectors
     ports:
-      - "8085:8080"
+      - "8086:8080"
     environment:
       - CAMUNDA_CLIENT_MODE=self-managed
       - CAMUNDA_CLIENT_GRPCADDRESS=http://zeebe:26500

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
     container_name: connectors
     ports:
-      - "8085:8080"
+      - "8086:8080"
     environment:
       # Zeebe connection
       - CAMUNDA_CLIENT_MODE=self-managed


### PR DESCRIPTION
As part of iteration 1 of

https://github.com/camunda/team-distribution/issues/578 ,

detailed in this comment
https://github.com/camunda/team-distribution/issues/578#issuecomment-3162202540

I will be aligning the port numbers between each deployment method.

The change in this PR switches the host port of connectors to be 8086 now instead of 8085. Web Modeler and Management Identity does not need to change since compose already uses the proper port numbers for these versions.