### PR TITLE
chore(web-modeler): remove unused command for restapi container

### DIFF
--- a/docker-compose/versions/camunda-8.3/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.3/docker-compose.yaml
@@ -379,7 +379,6 @@ services:
   modeler-restapi:
     container_name: modeler-restapi
     image: registry.camunda.cloud/web-modeler-ee/modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       modeler-db:
         condition: service_healthy

--- a/docker-compose/versions/camunda-8.4/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.4/docker-compose.yaml
@@ -399,7 +399,6 @@ services:
   modeler-restapi:
     container_name: modeler-restapi
     image: registry.camunda.cloud/web-modeler-ee/modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       modeler-db:
         condition: service_healthy

--- a/docker-compose/versions/camunda-8.5/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.5/docker-compose.yaml
@@ -413,7 +413,6 @@ services:
   modeler-restapi:
     container_name: modeler-restapi
     image: registry.camunda.cloud/web-modeler-ee/modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       modeler-db:
         condition: service_healthy

--- a/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
@@ -61,7 +61,6 @@ services:
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       web-modeler-db:
         condition: service_healthy

--- a/docker-compose/versions/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose.yaml
@@ -399,7 +399,6 @@ services:
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       web-modeler-db:
         condition: service_healthy

--- a/docker-compose/versions/camunda-8.7/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose-web-modeler.yaml
@@ -61,7 +61,6 @@ services:
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       web-modeler-db:
         condition: service_healthy

--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -413,7 +413,6 @@ services:
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       web-modeler-db:
         condition: service_healthy

--- a/docker-compose/versions/camunda-8.8/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-web-modeler.yaml
@@ -61,7 +61,6 @@ services:
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       web-modeler-db:
         condition: service_healthy

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -306,7 +306,6 @@ services:
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
-    command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
       web-modeler-db:
         condition: service_healthy


### PR DESCRIPTION
This custom command was actually never used by the application (see https://github.com/camunda/web-modeler/pull/16269#discussion_r2217329286).