### PR TITLE
refactor: adopt webmodeler file to new 8.8 setup

### DIFF
--- a/docker-compose/versions/camunda-8.8/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-web-modeler.yaml
@@ -7,17 +7,18 @@ services:
 
   web-modeler-db:
     container_name: web-modeler-db
-
     image: postgres:${POSTGRES_VERSION}
+    restart: on-failure
     healthcheck:
-      test: pg_isready -d web-modeler-db -U web-modeler-db-user
-      interval: 5s
-      timeout: 15s
-      retries: 30
+      test: ["CMD", "pg_isready", "-d", "${WEBMODELER_DB_NAME}", "-U", "${WEBMODELER_DB_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     environment:
-      POSTGRES_DB: web-modeler-db
-      POSTGRES_USER: web-modeler-db-user
-      POSTGRES_PASSWORD: web-modeler-db-password
+      POSTGRES_DB: ${WEBMODELER_DB_NAME}
+      POSTGRES_USER: ${WEBMODELER_DB_USER}
+      POSTGRES_PASSWORD: ${WEBMODELER_DB_PASSWORD}
     networks:
       - web-modeler
     volumes:
@@ -28,17 +29,19 @@ services:
     image: camunda/web-modeler-websockets:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8060:8060"
+    restart: on-failure
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8060/up"]
-      interval: 5s
-      timeout: 15s
-      retries: 30
+      test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://127.0.0.1:8060/up"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     environment:
       APP_NAME: "Web Modeler Self-Managed WebSockets"
       APP_DEBUG: "true"
-      PUSHER_APP_ID: web-modeler-app
-      PUSHER_APP_KEY: web-modeler-app-key
-      PUSHER_APP_SECRET: web-modeler-app-secret
+      PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}
+      PUSHER_APP_KEY: ${WEBMODELER_PUSHER_KEY}
+      PUSHER_APP_SECRET: ${WEBMODELER_PUSHER_SECRET}
     networks:
       - web-modeler
 
@@ -46,65 +49,61 @@ services:
     # If you want to use your own SMTP server, you can remove this container
     # and configure RESTAPI_MAIL_HOST, RESTAPI_MAIL_PORT, REST_API_MAIL_USER,
     # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in web-modeler-restapi
-    container_name: web-modeler-mailpit
+    container_name: mailpit
     image: axllent/mailpit:${MAILPIT_VERSION}
     ports:
       - "1025:1025"
       - "8075:8025"
+    restart: on-failure
     healthcheck:
-      test: /usr/bin/nc -v localhost 1025
+      test: ["CMD", "/usr/bin/nc", "-z", "localhost", "1025"]
       interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     networks:
       - web-modeler
 
-  # Modeler containers
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
+    restart: on-failure
     depends_on:
       web-modeler-db:
         condition: service_healthy
       mailpit:
-        condition: service_started
+        condition: service_healthy
       identity:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8091/health/readiness"]
-      interval: 5s
-      timeout: 15s
-      retries: 30
+      test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:8091/health/readiness"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
     environment:
       JAVA_OPTIONS: -Xmx512m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
-      SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/web-modeler-db
-      SPRING_DATASOURCE_USERNAME: web-modeler-db-user
-      SPRING_DATASOURCE_PASSWORD: web-modeler-db-password
+      SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/${WEBMODELER_DB_NAME}
+      SPRING_DATASOURCE_USERNAME: ${WEBMODELER_DB_USER}
+      SPRING_DATASOURCE_PASSWORD: ${WEBMODELER_DB_PASSWORD}
       SPRING_PROFILES_INCLUDE: default-logging
       RESTAPI_PUSHER_HOST: web-modeler-websockets
       RESTAPI_PUSHER_PORT: "8060"
-      RESTAPI_PUSHER_APP_ID: web-modeler-app
-      RESTAPI_PUSHER_KEY: web-modeler-app-key
-      RESTAPI_PUSHER_SECRET: web-modeler-app-secret
+      RESTAPI_PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}
+      RESTAPI_PUSHER_KEY: ${WEBMODELER_PUSHER_KEY}
+      RESTAPI_PUSHER_SECRET: ${WEBMODELER_PUSHER_SECRET}
       RESTAPI_OAUTH2_TOKEN_ISSUER: http://${HOST}:18080/auth/realms/camunda-platform
       RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
       RESTAPI_SERVER_URL: http://localhost:8070
       RESTAPI_MAIL_HOST: mailpit
       RESTAPI_MAIL_PORT: 1025
       RESTAPI_MAIL_ENABLE_TLS: "false"
-      RESTAPI_MAIL_FROM_ADDRESS: "noreply@example.com"
-      CAMUNDA_MODELER_CLUSTERS_0_ID: "local-orchestration"
-      CAMUNDA_MODELER_CLUSTERS_0_NAME: "Local Orchestration instance"
-      CAMUNDA_MODELER_CLUSTERS_0_VERSION: ${CAMUNDA_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_0_URL_GRPC: grpc://orchestration:26500
-      CAMUNDA_MODELER_CLUSTERS_0_URL_REST: http://orchestration:8080
-      CAMUNDA_MODELER_CLUSTERS_0_URL_WEBAPP: http://localhost:8088
-      CAMUNDA_MODELER_CLUSTERS_0_AUTHENTICATION: CLIENT_CREDENTIALS
-      CAMUNDA_MODELER_CLUSTERS_0_AUTHORIZATIONS_ENABLED: ${RESOURCE_AUTHORIZATIONS_ENABLED}
-      CAMUNDA_MODELER_CLUSTERS_0_OAUTH_URL: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-      CAMUNDA_MODELER_CLUSTERS_0_OAUTH_CLIENT_ID: ${ORCHESTRATION_CLIENT_ID}
-      CAMUNDA_MODELER_CLUSTERS_0_OAUTH_CLIENT_SECRET: ${ORCHESTRATION_CLIENT_SECRET}
-      CAMUNDA_MODELER_CLUSTERS_0_OAUTH_AUDIENCES_0: orchestration-api
+      RESTAPI_MAIL_FROM_ADDRESS: ${WEBMODELER_MAIL_FROM_ADDRESS}
+      management.endpoints.web.exposure.include: health,configprops
+      management.endpoint.health.probes.enabled: true
+      MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
     networks:
       - web-modeler
       - camunda-platform
@@ -114,30 +113,32 @@ services:
     image: camunda/web-modeler-webapp:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8070:8070"
+    restart: on-failure
     depends_on:
       web-modeler-restapi:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8071/health/readiness"]
-      interval: 5s
-      timeout: 15s
-      retries: 30
+      test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:8071/health/readiness"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     environment:
       RESTAPI_HOST: web-modeler-restapi
       SERVER_HTTPS_ONLY: "false"
       SERVER_URL: http://localhost:8070
-      PUSHER_APP_ID: web-modeler-app
-      PUSHER_KEY: web-modeler-app-key
-      PUSHER_SECRET: web-modeler-app-secret
+      PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}
+      PUSHER_KEY: ${WEBMODELER_PUSHER_KEY}
+      PUSHER_SECRET: ${WEBMODELER_PUSHER_SECRET}
       PUSHER_HOST: web-modeler-websockets
       PUSHER_PORT: "8060"
       CLIENT_PUSHER_HOST: localhost
       CLIENT_PUSHER_PORT: "8060"
       CLIENT_PUSHER_FORCE_TLS: "false"
-      CLIENT_PUSHER_KEY: web-modeler-app-key
+      CLIENT_PUSHER_KEY: ${WEBMODELER_PUSHER_KEY}
       OAUTH2_CLIENT_ID: web-modeler
       OAUTH2_JWKS_URL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
-      OAUTH2_TOKEN_AUDIENCE: web-modeler
+      OAUTH2_TOKEN_AUDIENCE: web-modeler-api
       OAUTH2_TOKEN_ISSUER: http://${HOST}:18080/auth/realms/camunda-platform
       IDENTITY_BASE_URL: http://identity:8084/
       PLAY_ENABLED: "true"
@@ -145,47 +146,30 @@ services:
       - web-modeler
       - camunda-platform
 
-  ## Dependencies: identity, keycloak, postgres for keycloak
-  identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
+  identity: # https://docs.camunda.io/docs/self-managed/setup/deploy/other/docker/#identity
     container_name: identity
     image: camunda/identity:${CAMUNDA_IDENTITY_VERSION}
     ports:
       - "8084:8084"
-    environment: # https://docs.camunda.io/docs/self-managed/identity/deployment/configuration-variables/
-      SERVER_PORT: 8084
-      IDENTITY_RETRY_DELAY_SECONDS: 30
-      IDENTITY_URL: http://${HOST}:8084
-      KEYCLOAK_URL: http://keycloak:18080/auth
-      IDENTITY_AUTH_PROVIDER_ISSUER_URL: http://${HOST}:18080/auth/realms/camunda-platform
-      IDENTITY_AUTH_PROVIDER_BACKEND_URL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
+    environment: # https://docs.camunda.io/docs/self-managed/identity/miscellaneous/configuration-variables/
       IDENTITY_DATABASE_HOST: postgres
       IDENTITY_DATABASE_PORT: 5432
-      IDENTITY_DATABASE_NAME: bitnami_keycloak
-      IDENTITY_DATABASE_USERNAME: bn_keycloak
-      IDENTITY_DATABASE_PASSWORD: "demo-postgres-password"
-      # Keycloak user initialization
-      KEYCLOAK_USERS_0_USERNAME: "demo"
-      KEYCLOAK_USERS_0_PASSWORD: "demo"
-      KEYCLOAK_USERS_0_FIRST_NAME: "Demo"
-      KEYCLOAK_USERS_0_EMAIL: "demo@example.com"
-      KEYCLOAK_USERS_0_ROLES_0: "Web Modeler"
-      KEYCLOAK_USERS_0_ROLES_1: "Web Modeler Admin"
-      # Web Modeler client configuration
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APPLICATIONS_0_NAME: "Web Modeler"
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APPLICATIONS_0_ID: "web-modeler"
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APPLICATIONS_0_TYPE: "public"
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APPLICATIONS_0_ROOT_URL: "http://${HOST}:8070"
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APPLICATIONS_0_REDIRECT_URIS_0: "/login-callback"
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APIS_0_NAME: "Web Modeler Internal API"
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APIS_0_AUDIENCE: "web-modeler-api"
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APIS_0_PERMISSIONS_0_DEFINITION: "write:*"
-      IDENTITY_COMPONENT_PRESETS_WEBMODELER_APIS_0_PERMISSIONS_0_DESCRIPTION: "Write permission"
+      IDENTITY_DATABASE_NAME: ${POSTGRES_DB}
+      IDENTITY_DATABASE_USERNAME: ${POSTGRES_USER}
+      IDENTITY_DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
+      KEYCLOAK_ADMIN_USER: ${KEYCLOAK_ADMIN_USER}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      HOST: ${HOST}
+      KEYCLOAK_HOST: ${KEYCLOAK_HOST}
       # Orchestration client (for Web Modeler to deploy to orchestration if available)
       KEYCLOAK_CLIENTS_0_NAME: "orchestration"
       KEYCLOAK_CLIENTS_0_ID: ${ORCHESTRATION_CLIENT_ID}
       KEYCLOAK_CLIENTS_0_SECRET: ${ORCHESTRATION_CLIENT_SECRET}
       KEYCLOAK_CLIENTS_0_TYPE: "M2M"
       RESOURCE_PERMISSIONS_ENABLED: ${RESOURCE_AUTHORIZATIONS_ENABLED}
+      management.endpoints.web.exposure.include: health,configprops
+      management.endpoint.health.probes.enabled: true
+      MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
     healthcheck:
       test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:8082/actuator/health"]
       interval: 5s
@@ -195,6 +179,7 @@ services:
     restart: on-failure
     volumes:
       - keycloak-theme:/app/keycloak-theme
+      - "./.identity/application.yaml:/app/application.yaml"
     networks:
       - camunda-platform
       - identity-network
@@ -206,15 +191,16 @@ services:
     container_name: postgres
     image: postgres:${POSTGRES_VERSION}
     environment:
-      POSTGRES_DB: bitnami_keycloak
-      POSTGRES_USER: bn_keycloak
-      POSTGRES_PASSWORD: "demo-postgres-password"
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 10s
     volumes:
       - postgres:/var/lib/postgresql/data
     networks:
@@ -231,9 +217,9 @@ services:
       KEYCLOAK_HTTP_PORT: 18080
       KEYCLOAK_HTTP_RELATIVE_PATH: /auth
       KEYCLOAK_DATABASE_HOST: postgres
-      KEYCLOAK_DATABASE_PASSWORD: "demo-postgres-password"
-      KEYCLOAK_ADMIN_USER: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KEYCLOAK_DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
+      KEYCLOAK_ADMIN_USER: ${KEYCLOAK_ADMIN_USER}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
     restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:18080/auth"]
@@ -245,7 +231,8 @@ services:
       - camunda-platform
       - identity-network
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
 networks:
   camunda-platform:


### PR DESCRIPTION
Part of https://github.com/camunda/camunda-distributions/issues/229

Adjust docker-compose-web-modeler.yaml to follow same configuration and setup as docker-compose-full.yaml (see [PR](https://github.com/camunda/camunda-distributions/pull/234))

Tested access (localhost:8070) and navigation ✅ 