### PR TITLE
fix: camunda/connectors image should actually be connectors-bundle

### DIFF
--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
   # Camunda Connectors - executes outbound and inbound connector logic
   # Docs: https://docs.camunda.io/docs/self-managed/connectors-deployment/connectors-configuration/
   connectors:
-    image: camunda/connectors:${CAMUNDA_CONNECTORS_VERSION}
+    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
     container_name: connectors
     ports:
       - "8086:8080"

--- a/docker-compose/versions/camunda-8.9/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
   # Camunda Connectors - executes outbound and inbound connector logic
   # Docs: https://docs.camunda.io/docs/self-managed/connectors-deployment/connectors-configuration/
   connectors:
-    image: camunda/connectors:${CAMUNDA_CONNECTORS_VERSION}
+    image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
     container_name: connectors
     ports:
       - "8086:8080"


### PR DESCRIPTION
https://camunda.slack.com/archives/C03UR0V2R2M/p1760451550025809

the difference between camunda/connectors and camunda/connectors-bundle is that bundle includes all the OOTB connectors. we should be using this image name, and I think the reason we changed this to connectors was just a mistake due to not immediately seeing it in DockerHub

<img width="974" height="703" alt="2025-10-14-103942_grim" src="https://github.com/user-attachments/assets/07fd3392-3e18-44f1-a291-8d0680e27a89" />

(it's at the bottom and not easily visible)