### PR TITLE
fix: connectors secretprovider prefix option added

### DIFF
--- a/docker-compose/versions/camunda-8.8/.connectors/application.yaml
+++ b/docker-compose/versions/camunda-8.8/.connectors/application.yaml
@@ -8,6 +8,10 @@ camunda:
       method: oidc
       credentialsCachePath: /tmp/orchestration_auth_cache
       audience: orchestration-api
+  connectors:
+    secretprovider:
+      environment:
+        prefix: "CONNECTORS_SECRET"
 
 management:
   endpoints:

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -18,7 +18,6 @@ services:
       - "8088:8080"
     environment:
       - JAVA_TOOL_OPTIONS="-XX:+PrintFlagsFinal"
-    mem_limit: 1g
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/9600 && echo -e \"GET /actuator/health/status HTTP/1.1\r\nHost: localhost\r\n\r\n\" >&3 && head -n 1 <&3'"]
@@ -47,7 +46,6 @@ services:
       - management.endpoints.web.exposure.include=health,configprops
       - management.endpoint.health.probes.enabled=true
     env_file: connector-secrets.txt
-    mem_limit: 512m
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness"]
@@ -78,7 +76,6 @@ services:
       - cluster.routing.allocation.disk.threshold_enabled=false
       # Disable noisy deprecation logs, see https://github.com/camunda/camunda/issues/26285
       - logger.org.elasticsearch.deprecation="OFF"
-    mem_limit: 1g
     restart: unless-stopped
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:9200/_cat/health | grep -q green" ]
@@ -106,6 +103,10 @@ configs:
           mode: self-managed
           grpc-address: http://orchestration:26500
           rest-address: http://orchestration:8080
+        connectors:
+          secretprovider:
+            environment:
+              prefix: "CONNECTORS_SECRET"
 
   orchestration-config:
     content: |

--- a/docker-compose/versions/camunda-8.9/.connectors/application.yaml
+++ b/docker-compose/versions/camunda-8.9/.connectors/application.yaml
@@ -8,6 +8,10 @@ camunda:
       method: oidc
       credentialsCachePath: /tmp/orchestration_auth_cache
       audience: orchestration-api
+  connectors:
+    secretprovider:
+      environment:
+        prefix: "CONNECTORS_SECRET"
 
 management:
   endpoints:

--- a/docker-compose/versions/camunda-8.9/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose.yaml
@@ -106,6 +106,10 @@ configs:
           mode: self-managed
           grpc-address: http://orchestration:26500
           rest-address: http://orchestration:8080
+        connectors:
+          secretprovider:
+            environment:
+              prefix: "CONNECTORS_SECRET"
 
   orchestration-config:
     content: |


### PR DESCRIPTION
```
connectors     | Currently, all environment variables will be exposed as connector secrets.
connectors     | This is unsafe and will not be supported anymore in future releases.
connectors     |
connectors     | Please configure a valid prefix using
connectors     | `camunda.connector.secretprovider.environment.prefix`
connectors     | or
connectors     | `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX`.
connectors     |
connectors     | If `camunda.connector.secretprovider.environment.enabled` is set to true,
connectors     | a prefix must be configured to avoid breaking changes in the future.
connectors     | 
```