### PR TITLE
fix: fix renovate config for 8.9

### DIFF
--- a/.github/config/renovatebot/renovate-docker-compose.json5
+++ b/.github/config/renovatebot/renovate-docker-compose.json5
@@ -65,8 +65,8 @@
     },
     {
       groupName: "camunda-docker-compose-8.9",
-      addLabels: ["version/8.8", "deps/docker-compose"],
-      matchFileNames: ["docker-compose/versions/camunda-8.8/**"],
+      addLabels: ["version/8.9", "deps/docker-compose"],
+      matchFileNames: ["docker-compose/versions/camunda-8.9/**"],
       // Allows only patch and alpha, but no -rc (e.g., 8.7.0, 8.7.0-alpha3, but no 8.7.0-alpha3-rc1).
       "allowedVersions": "/^8\\.8\\.\\d+(-alpha[0-9]*)?$/"
     },


### PR DESCRIPTION
Related to https://github.com/camunda/team-distribution/issues/620

Fixing a misconfig in the renovate update config for 8.9 (still pointing to 8.8).

