### PR TITLE
chore: update c8run es version to 8.19.10

### DIFF
--- a/docker-compose/versions/camunda-8.9/.env
+++ b/docker-compose/versions/camunda-8.9/.env
@@ -16,7 +16,7 @@ CAMUNDA_WEB_MODELER_VERSION=8.9.0-alpha1
 # renovate: datasource=docker depName=camunda/console
 CAMUNDA_CONSOLE_VERSION=8.9.0-alpha1
 # renovate: datasource=docker depName=elasticsearch
-ELASTIC_VERSION=8.17.10
+ELASTIC_VERSION=8.19.10
 KEYCLOAK_SERVER_VERSION=26.3.2
 # renovate: datasource=docker depName=axllent/mailpit
 MAILPIT_VERSION=v1.21.8


### PR DESCRIPTION
related to https://github.com/camunda/camunda-platform-helm/issues/5029

All 8.9 docker files were healthy when tested.