### PR TITLE
refactor(web-modeler): call restapi directly from frontend

### DIFF
--- a/docker-compose/versions/camunda-8.9/.env
+++ b/docker-compose/versions/camunda-8.9/.env
@@ -12,7 +12,7 @@ CAMUNDA_TASKLIST_VERSION=8.9.0-alpha1
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.9.0-alpha1.1
 # renovate: datasource=docker depName=camunda/web-modeler-restapi
-CAMUNDA_WEB_MODELER_VERSION=8.9.0-alpha1
+CAMUNDA_WEB_MODELER_VERSION=8.9.0-alpha4
 # renovate: datasource=docker depName=camunda/console
 CAMUNDA_CONSOLE_VERSION=8.9.0-alpha1
 # renovate: datasource=docker depName=elasticsearch

--- a/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
@@ -292,6 +292,8 @@ services:
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
+    ports:
+      - "8081:8081"
     restart: on-failure
     depends_on:
       web-modeler-db:
@@ -337,6 +339,8 @@ services:
       management.endpoints.web.exposure.include: health,configprops
       management.endpoint.health.probes.enabled: true
       MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
+      CAMUNDA_MODELER_CORS_INTERNAL_API_ENABLED: true
+      CAMUNDA_MODELER_CORS_INTERNAL_API_ALLOWED_ORIGINS: http://localhost:8070
     networks:
       - web-modeler
       - camunda-platform
@@ -360,6 +364,7 @@ services:
       start_period: 30s
     environment:
       RESTAPI_HOST: web-modeler-restapi
+      RESTAPI_PUBLIC_URL: http://localhost:8081
       SERVER_HTTPS_ONLY: "false"
       SERVER_URL: http://localhost:8070
       PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}

--- a/docker-compose/versions/camunda-8.9/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose-web-modeler.yaml
@@ -73,6 +73,8 @@ services:
   web-modeler-restapi:
     container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
+    ports:
+      - "8081:8081"
     restart: on-failure
     depends_on:
       web-modeler-db:
@@ -110,6 +112,8 @@ services:
       management.endpoints.web.exposure.include: health,configprops
       management.endpoint.health.probes.enabled: true
       MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
+      CAMUNDA_MODELER_CORS_INTERNAL_API_ENABLED: true
+      CAMUNDA_MODELER_CORS_INTERNAL_API_ALLOWED_ORIGINS: http://localhost:8070
     networks:
       - web-modeler
       - camunda-platform
@@ -133,6 +137,7 @@ services:
       start_period: 30s
     environment:
       RESTAPI_HOST: web-modeler-restapi
+      RESTAPI_PUBLIC_URL: http://localhost:8081
       SERVER_HTTPS_ONLY: "false"
       SERVER_URL: http://localhost:8070
       PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}


### PR DESCRIPTION
Call the Web Modeler `restapi` container directly from the frontend (requests will not be proxied through the `webapp` any more).

Closes https://github.com/camunda/web-modeler/issues/20415.

ℹ️ Only works properly with the changes from https://github.com/camunda/web-modeler/pull/20595, so I've also updated the Web Modeler version to the latest `8.9.0-alpha4`.