### PR TITLE
fix: use wget instead of curl for connectors healthcheck

### DIFF
--- a/docker-compose/versions/camunda-8.6/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-core.yaml
@@ -107,7 +107,7 @@ services:
       - management.endpoints.web.exposure.include=health
       - management.endpoint.health.probes.enabled=true
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness" ]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s
       timeout: 1s
       retries: 5

--- a/docker-compose/versions/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose.yaml
@@ -170,7 +170,7 @@ services:
       - management.endpoint.health.probes.enabled=true
     env_file: connector-secrets.txt
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness"]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s
       timeout: 1s
       retries: 5

--- a/docker-compose/versions/camunda-8.7/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose-core.yaml
@@ -109,7 +109,7 @@ services:
       - logging.level.io.camunda.zeebe.client.impl.ZeebeCallCredentials=ERROR
       - logging.level.io.camunda.connector.runtime.inbound.importer=ERROR
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness" ]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s
       timeout: 1s
       retries: 5

--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -184,7 +184,7 @@ services:
       - management.endpoint.health.probes.enabled=true
     env_file: connector-secrets.txt
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness"]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s
       timeout: 1s
       retries: 5

--- a/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
@@ -74,7 +74,7 @@ services:
     env_file: connector-secrets.txt
     restart: on-failure
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health/readiness"]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
     env_file: connector-secrets.txt
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness"]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
The connectors-bundle image no longer includes curl starting from versions 8.6.24, 8.7.15, and 8.8.7.

This broke the healthcheck which relied on curl. Replaced with wget which is available in the image.

Fixes failing Renovate PRs #306, #312, #313.