### PR TITLE
Adding missing Web Modeler API permissions

### DIFF
--- a/docker-compose/versions/camunda-8.8/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.8/.identity/application.yaml
@@ -120,6 +120,17 @@ identity:
               description: "Write permission"
             - definition: admin:*
               description: "Admin permission"
+        - name: Web Modeler API
+          audience: "web-modeler-public-api"
+          permissions:
+            - definition: create:*
+              description: "Allows create access for all resources"
+            - definition: read:*
+              description: "Allows read access to all resources"
+            - definition: update:*
+              description: "Allows update access to all resources"
+            - definition: delete:*
+              description: "Allows delete access for all resources"
       roles:
         - name: "Web Modeler"
           description: "Grants full access to Web Modeler"

--- a/docker-compose/versions/camunda-8.9/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.9/.identity/application.yaml
@@ -120,6 +120,17 @@ identity:
               description: "Write permission"
             - definition: admin:*
               description: "Admin permission"
+        - name: Web Modeler API
+          audience: "web-modeler-public-api"
+          permissions:
+            - definition: create:*
+              description: "Allows create access for all resources"
+            - definition: read:*
+              description: "Allows read access to all resources"
+            - definition: update:*
+              description: "Allows update access to all resources"
+            - definition: delete:*
+              description: "Allows delete access for all resources"
       roles:
         - name: "Web Modeler"
           description: "Grants full access to Web Modeler"


### PR DESCRIPTION
`camunda-platform-helm `8.8 has the below permissions in Identity configmap, however, these are not present in `camunda-distributions` 8.8 .identity/application.yaml:

```
- name: Web Modeler API
      audience: "web-modeler-public-api"
      permissions:
        - definition: create:*
          description: "Allows create access for all resources"
        - definition: read:*
          description: "Allows read access to all resources"
        - definition: update:*
          description: "Allows update access to all resources"
        - definition: delete:*
          description: "Allows delete access for all resources"
 ```
 
 I am adding missing permissions.
 
 closes #[45173](https://github.com/camunda/camunda/issues/45173)