### PR TITLE
fix: zeebe disk has moved

### DIFF
--- a/docker-compose/versions/camunda-8.9/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       retries: 30
       start_period: 30s
     volumes:
-      - zeebe:/usr/local/zeebe/data
+      - camunda:/usr/local/camunda/data
       - camunda-data:/usr/local/camunda/camunda-data
       - ./driver-lib:/driver-lib:ro
     configs:
@@ -104,7 +104,7 @@ services:
       - camunda
 
 volumes:
-  zeebe:
+  camunda:
   elastic:
   camunda-data:
 


### PR DESCRIPTION
Zeebe disk has moved to `/usr/local/camunda/data`.

Currenly, zeebe state is not persisted and lost on restart of OC.