### PR TITLE
fix: remove redundant connectors config

### DIFF
--- a/docker-compose/versions/camunda-8.9/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose.yaml
@@ -119,10 +119,6 @@ configs:
           mode: self-managed
           grpc-address: http://orchestration:26500
           rest-address: http://orchestration:8080
-        connectors:
-          secretprovider:
-            environment:
-              prefix: "CONNECTORS_SECRET"
 
   orchestration-config:
     file: ./configuration/${ORCHESTRATION_CONFIG_FILE:-application-h2.yaml}


### PR DESCRIPTION
This configuration is not effective anyway as it would have to be `camunda.connector.secretprovider.environment.prefix`.

But after all, connectors sets a meaningful default `SECRETS_`.

So, I would vote for removing it and stick to the default!