### PR TITLE
fix: remove es as h2 is used

### DIFF
--- a/docker-compose/versions/camunda-8.9/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose.yaml
@@ -45,8 +45,6 @@ services:
     depends_on:
       camunda-data-init:
         condition: service_completed_successfully
-      elasticsearch:
-        condition: service_healthy
 
   # Camunda Connectors - executes outbound and inbound connector logic
   # Docs: https://docs.camunda.io/docs/self-managed/connectors-deployment/connectors-configuration/
@@ -77,35 +75,8 @@ services:
         # Wait for orchestration service to be healthy, otherwise we get a lot of noisy logs from connection errors
         condition: service_healthy
 
-  elasticsearch: # https://hub.docker.com/_/elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
-    container_name: elasticsearch
-    ports:
-      - "9200:9200"
-      - "9300:9300"
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-      # allow running with low disk space
-      - cluster.routing.allocation.disk.threshold_enabled=false
-      # Disable noisy deprecation logs, see https://github.com/camunda/camunda/issues/26285
-      - logger.org.elasticsearch.deprecation="OFF"
-    mem_limit: 1g
-    restart: unless-stopped
-    healthcheck:
-      test: [ "CMD-SHELL", "curl -fsS http://localhost:9200/_cat/health?h=status | grep -Eq 'green|yellow'" ]
-      interval: 1s
-      retries: 30
-      start_period: 30s
-      timeout: 1s
-    volumes:
-      - elastic:/usr/share/elasticsearch/data
-    networks:
-      - camunda
-
 volumes:
   zeebe:
-  elastic:
   camunda-data:
 
 networks:


### PR DESCRIPTION
The Elasticsearch is redundant in this setup, as OC is configured to use h2 by default.