### PR TITLE
fix: remove workflow-level permissions block from PR notify caller

### DIFF
--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -12,8 +12,6 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, closed]
 
-permissions: {}
-
 jobs:
   notify:
     if: |


### PR DESCRIPTION
## Summary
- `permissions: {}` at the workflow level prevents the called reusable workflow from acquiring `contents: read`, causing a workflow file validation error before any jobs start (run [#24585709352](https://github.com/camunda/camunda-distributions/actions/runs/24585709352))
- Removed the `permissions: {}` block — the called workflow in `camunda/team-distribution` declares its own permissions at the job level

🤖 Generated with [Claude Code](https://claude.com/claude-code)