### PR TITLE
test: verify PR activity Slack notification

### DIFF
--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -41,3 +41,4 @@ jobs:
       VAULT_ADDR:       ${{ secrets.VAULT_ADDR }}
       VAULT_ROLE_ID:    ${{ secrets.VAULT_ROLE_ID }}
       VAULT_SECRET_ID:  ${{ secrets.VAULT_SECRET_ID }}
+


### PR DESCRIPTION
Test PR to verify the notify-pr-activity workflow fires correctly after fixing the reusable workflow access settings. Safe to close without merging.