### PR TITLE
chore(hub): updating references in 8.10 for new hub repositories

### DIFF
--- a/.github/workflows/docker-compose-test-e2e-template.yaml
+++ b/.github/workflows/docker-compose-test-e2e-template.yaml
@@ -73,12 +73,15 @@ jobs:
             secret/data/products/distribution/ci DOCKERHUB_PASSWORD;
           exportEnv: true
 
-      - name: Login to Docker registries
+      - name: Login to DockerHub
         run: |
-          # DockerHub registry.
           echo '${{ env.DOCKERHUB_PASSWORD }}' |
             docker login -u '${{ env.DOCKERHUB_USERNAME }}' --password-stdin
-          # Camunda registry.
+
+      - name: Login to Camunda registry
+        # Only 8.3–8.5 pull images from registry.camunda.cloud; later versions use DockerHub.
+        if: ${{ contains(fromJSON('["8.3","8.4","8.5"]'), inputs.camunda-version) }}
+        run: |
           echo '${{ env.HARBOR_REGISTRY_PASSWORD }}' |
             docker login -u '${{ env.HARBOR_REGISTRY_USER }}' --password-stdin registry.camunda.cloud
 

--- a/docker-compose/versions/camunda-8.10/.console/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.console/application.yaml
@@ -64,10 +64,10 @@ camunda:
               readiness: "http://keycloak:18080/auth"
             - name: "WebModeler"
               id: "webModelerWebApp"
-              # renovate: datasource=docker depName=camunda/web-modeler-restapi
+              # renovate: datasource=docker depName=camunda/hub
               version: "8.9.0"
               url: "http://localhost:8070"
-              readiness: "http://web-modeler-restapi:8091/health/readiness"
+              readiness: "http://hub:8091/health/readiness"
             - name: "Connectors"
               id: "connectors"
               # renovate: datasource=docker depName=camunda/connectors-bundle

--- a/docker-compose/versions/camunda-8.10/.console/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.console/application.yaml
@@ -65,7 +65,7 @@ camunda:
             - name: "WebModeler"
               id: "webModelerWebApp"
               # renovate: datasource=docker depName=camunda/hub
-              version: "8.9.0"
+              version: "8.10.0-alpha1"
               url: "http://localhost:8070"
               readiness: "http://hub:8091/health/readiness"
             - name: "Connectors"

--- a/docker-compose/versions/camunda-8.10/.env
+++ b/docker-compose/versions/camunda-8.10/.env
@@ -13,7 +13,7 @@ CAMUNDA_TASKLIST_VERSION=8.10-SNAPSHOT
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.10-SNAPSHOT
 # renovate: datasource=docker depName=camunda/hub
-CAMUNDA_WEB_MODELER_VERSION=8.9.3
+CAMUNDA_WEB_MODELER_VERSION=8.10.0-alpha1
 # renovate: datasource=docker depName=camunda/console
 CAMUNDA_CONSOLE_VERSION=8.10-SNAPSHOT
 KEYCLOAK_SERVER_VERSION=26.3.2

--- a/docker-compose/versions/camunda-8.10/.env
+++ b/docker-compose/versions/camunda-8.10/.env
@@ -12,8 +12,7 @@ CAMUNDA_OPERATE_VERSION=8.10-SNAPSHOT
 CAMUNDA_TASKLIST_VERSION=8.10-SNAPSHOT
 # renovate: datasource=docker depName=camunda/optimize
 CAMUNDA_OPTIMIZE_VERSION=8.10-SNAPSHOT
-# No verified 8.10-SNAPSHOT tag yet, keep the inherited 8.9 version for now.
-# renovate: datasource=docker depName=camunda/web-modeler-restapi
+# renovate: datasource=docker depName=camunda/hub
 CAMUNDA_WEB_MODELER_VERSION=8.9.3
 # renovate: datasource=docker depName=camunda/console
 CAMUNDA_CONSOLE_VERSION=8.10-SNAPSHOT

--- a/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
@@ -253,7 +253,7 @@ services:
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
     # and configure RESTAPI_MAIL_HOST, RESTAPI_MAIL_PORT, REST_API_MAIL_USER,
-    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in web-modeler-restapi
+    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in hub
     container_name: mailpit
     image: axllent/mailpit:${MAILPIT_VERSION}
     ports:
@@ -271,9 +271,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  web-modeler-restapi:
-    container_name: web-modeler-restapi
-    image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
+  hub:
+    container_name: hub
+    image: camunda/hub:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8070:8081"
     restart: on-failure
@@ -298,7 +298,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${WEBMODELER_DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${WEBMODELER_DB_PASSWORD}
       SPRING_PROFILES_INCLUDE: default-logging
-      RESTAPI_PUSHER_HOST: web-modeler-websockets
+      RESTAPI_PUSHER_HOST: hub-websockets
       RESTAPI_PUSHER_PORT: "8060"
       RESTAPI_PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}
       RESTAPI_PUSHER_KEY: ${WEBMODELER_PUSHER_KEY}
@@ -334,9 +334,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  web-modeler-websockets:
-    container_name: web-modeler-websockets
-    image: camunda/web-modeler-websockets:${CAMUNDA_WEB_MODELER_VERSION}
+  hub-websockets:
+    container_name: hub-websockets
+    image: camunda/hub-websockets:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8060:8060"
     restart: on-failure

--- a/docker-compose/versions/camunda-8.10/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-web-modeler.yaml
@@ -26,9 +26,9 @@ services:
     volumes:
       - postgres-web:/var/lib/postgresql/data
 
-  web-modeler-websockets:
-    container_name: web-modeler-websockets
-    image: camunda/web-modeler-websockets:${CAMUNDA_WEB_MODELER_VERSION}
+  hub-websockets:
+    container_name: hub-websockets
+    image: camunda/hub-websockets:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8060:8060"
     restart: on-failure
@@ -52,7 +52,7 @@ services:
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
     # and configure RESTAPI_MAIL_HOST, RESTAPI_MAIL_PORT, REST_API_MAIL_USER,
-    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in web-modeler-restapi
+    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in hub
     container_name: mailpit
     image: axllent/mailpit:${MAILPIT_VERSION}
     ports:
@@ -70,9 +70,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  web-modeler-restapi:
-    container_name: web-modeler-restapi
-    image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
+  hub:
+    container_name: hub
+    image: camunda/hub:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8070:8081"
     restart: on-failure
@@ -97,7 +97,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${WEBMODELER_DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${WEBMODELER_DB_PASSWORD}
       SPRING_PROFILES_INCLUDE: default-logging
-      RESTAPI_PUSHER_HOST: web-modeler-websockets
+      RESTAPI_PUSHER_HOST: hub-websockets
       RESTAPI_PUSHER_PORT: "8060"
       RESTAPI_PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}
       RESTAPI_PUSHER_KEY: ${WEBMODELER_PUSHER_KEY}


### PR DESCRIPTION
Closes #394

## Summary

Updates the Camunda 8.10 Docker Compose configuration to replace all references to the `web-modeler-restapi` / `web-modeler-websockets` services with the new `hub` / `hub-websockets` services, aligning with upstream image renames in 8.10.

### Service renaming

- `web-modeler-restapi` → `hub` in `docker-compose-full.yaml` and `docker-compose-web-modeler.yaml` (container name, image, all internal references)
- `web-modeler-websockets` → `hub-websockets` in both compose files
- Updated `RESTAPI_PUSHER_HOST`, comments, and Console readiness endpoint to match new service names
- Updated `.console/application.yaml` Renovate hint from `camunda/web-modeler-restapi` to `camunda/hub`

### `.env` fixes

- Updated Renovate datasource hint for `CAMUNDA_WEB_MODELER_VERSION` from `camunda/web-modeler-restapi` to `camunda/hub`
- Bumped `CAMUNDA_WEB_MODELER_VERSION` to `8.10.0-alpha1` (was incorrectly left at `8.9.3`)

### CI fix

- Scoped the Camunda registry (`registry.camunda.cloud`) login to versions 8.3–8.5 only — those are the only versions that pull images from Harbor. From 8.6 onwards all images are on DockerHub, so the unconditional Harbor login was failing unnecessarily for 8.10.