### PR TITLE
fix(docker-compose): use singular 'connector' key for secret provider

### DIFF
--- a/docker-compose/versions/camunda-8.10/.connectors/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.connectors/application.yaml
@@ -8,7 +8,7 @@ camunda:
       method: oidc
       credentialsCachePath: /tmp/orchestration_auth_cache
       audience: orchestration-api
-  connectors:
+  connector:
     secretprovider:
       environment:
         prefix: "CONNECTORS_SECRET"

--- a/docker-compose/versions/camunda-8.10/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose.yaml
@@ -91,7 +91,7 @@ configs:
           mode: self-managed
           grpc-address: http://orchestration:26500
           rest-address: http://orchestration:8080
-        connectors:
+        connector:
           secretprovider:
             environment:
               prefix: "CONNECTORS_SECRET"

--- a/docker-compose/versions/camunda-8.8/.connectors/application.yaml
+++ b/docker-compose/versions/camunda-8.8/.connectors/application.yaml
@@ -8,7 +8,7 @@ camunda:
       method: oidc
       credentialsCachePath: /tmp/orchestration_auth_cache
       audience: orchestration-api
-  connectors:
+  connector:
     secretprovider:
       environment:
         prefix: "CONNECTORS_SECRET"

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -101,7 +101,7 @@ configs:
           mode: self-managed
           grpc-address: http://orchestration:26500
           rest-address: http://orchestration:8080
-        connectors:
+        connector:
           secretprovider:
             environment:
               prefix: "CONNECTORS_SECRET"

--- a/docker-compose/versions/camunda-8.9/.connectors/application.yaml
+++ b/docker-compose/versions/camunda-8.9/.connectors/application.yaml
@@ -8,7 +8,7 @@ camunda:
       method: oidc
       credentialsCachePath: /tmp/orchestration_auth_cache
       audience: orchestration-api
-  connectors:
+  connector:
     secretprovider:
       environment:
         prefix: "CONNECTORS_SECRET"


### PR DESCRIPTION
## Summary

- Renames the secret-provider parent key from `camunda.connectors.secretprovider` (plural) to `camunda.connector.secretprovider` (singular) in the connectors config for 8.8, 8.9, and 8.10.
- The connectors runtime only reads the singular form, so the existing config silently did nothing — every connectors container logged the `EnvironmentSecretProvider: prefix is not configured` warning, and all environment variables were exposed as connector secrets.

Closes #410. Support: https://jira.camunda.com/browse/SUPPORT-32666.

## Files changed

- `docker-compose/versions/camunda-8.8/docker-compose.yaml` — inline `configs.connectors-config.content`
- `docker-compose/versions/camunda-8.8/.connectors/application.yaml`
- `docker-compose/versions/camunda-8.9/.connectors/application.yaml`
- `docker-compose/versions/camunda-8.10/docker-compose.yaml` — inline `configs.connectors-config.content`
- `docker-compose/versions/camunda-8.10/.connectors/application.yaml`

> Note: the linked issue listed 6 files, but `docker-compose/versions/camunda-8.9/docker-compose.yaml` does not actually contain a `secretprovider` block (only `client` config), so it is not affected by this bug. That is a separate gap (8.9 lightweight stack does not configure a prefix at all) and out of scope here.

## Verification

Verified locally against the unmodified 8.8 stack with `camunda/connectors-bundle:8.8.10`:

- Before (plural `connectors:`): warning is logged.
- After (singular `connector:`): warning is gone.

Cross-checked using the env-var override `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX` (silences the warning) vs. `CAMUNDA_CONNECTORS_SECRETPROVIDER_ENVIRONMENT_PREFIX` (does not).

The runtime's own warning text is misleading — it suggests the plural key path that does not work. That is an upstream bug in the connectors runtime warning message and should be tracked separately on `camunda/camunda`.

## Test plan

- [ ] CI matrix: 8.8 ⭐, 8.9 ⭐, 8.10 jobs pass (lightweight + full stacks).
- [ ] Manually inspect `docker logs connectors` for each minor and confirm the `EnvironmentSecretProvider: prefix is not configured` warning is no longer present.
- [ ] Confirm a connector that uses `{{secrets.SOMETHING}}` still resolves an env var prefixed with `CONNECTORS_SECRET_` (i.e. the prefix is now actually applied, not just the warning suppressed).