### PR TITLE
fix(docker-compose): mount connectors config to path Spring Boot reads

### DIFF
--- a/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
@@ -89,7 +89,7 @@ services:
       retries: 5
       start_period: 30s
     volumes:
-      - "./.connectors/application.yaml:/app/application.yaml"
+      - "./.connectors/application.yaml:/application.yaml"
     networks:
       - camunda-platform
     extra_hosts:

--- a/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
@@ -80,7 +80,7 @@ services:
       retries: 5
       start_period: 30s
     volumes:
-      - "./.connectors/application.yaml:/app/application.yaml"
+      - "./.connectors/application.yaml:/application.yaml"
     networks:
       - camunda-platform
     extra_hosts:

--- a/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
@@ -90,7 +90,7 @@ services:
       retries: 5
       start_period: 30s
     volumes:
-      - "./.connectors/application.yaml:/app/application.yaml"
+      - "./.connectors/application.yaml:/application.yaml"
     networks:
       - camunda-platform
     extra_hosts:


### PR DESCRIPTION
## Summary

- Changes the connectors `application.yaml` bind-mount target from `/app/application.yaml` to `/application.yaml` in the full-stack compose files for 8.8, 8.9, and 8.10.
- The `connectors-bundle` image has `WORKDIR=/` and no `SPRING_CONFIG_LOCATION` override, so Spring Boot only searches `classpath:/`, `classpath:/config/`, `file:/`, and `file:/config/`. The previous mount at `/app/application.yaml` was never in the search path, making the config file dead code.

Closes #412. Support: https://jira.camunda.com/browse/SUPPORT-32666 (related).

## Files changed

- `docker-compose/versions/camunda-8.8/docker-compose-full.yaml`
- `docker-compose/versions/camunda-8.9/docker-compose-full.yaml`
- `docker-compose/versions/camunda-8.10/docker-compose-full.yaml`

## Verification

Tested locally on the 8.8 full stack with `camunda/connectors-bundle:8.8.11`:

| Mount target | `EnvironmentSecretProvider` warning |
|---|---|
| `/app/application.yaml` (before) | present |
| `/application.yaml` (after) | absent |

This matches the approach the lightweight stack already uses (`configs` with `target: application.yaml` → `/application.yaml`).

## Test plan

- [ ] CI: 8.8, 8.9, 8.10 full-stack jobs pass.
- [ ] Manually inspect `docker logs connectors` on 8.8 full stack and confirm the `EnvironmentSecretProvider: prefix is not configured` warning is no longer present.
- [ ] On 8.8/8.9/8.10 full stacks, a sentinel value added to `.connectors/application.yaml` is observable via `/actuator/configprops`, proving the file is loaded.