### PR TITLE
feat: explicit names for default compose networks

### DIFF
--- a/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
@@ -404,5 +404,8 @@ networks:
   # It is also part of the camunda-platform network to communicate with the platform components like Orchestration to run
   # processes or Identity to log in.
   camunda-platform:
+    name: camunda-platform
   identity-network:
+    name: identity-network
   web-modeler:
+    name: web-modeler

--- a/docker-compose/versions/camunda-8.10/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-web-modeler.yaml
@@ -221,8 +221,11 @@ services:
 
 networks:
   camunda-platform:
+    name: camunda-platform
   identity-network:
+    name: identity-network
   web-modeler:
+    name: web-modeler
 
 volumes:
   postgres:

--- a/docker-compose/versions/camunda-8.10/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose.yaml
@@ -82,6 +82,7 @@ volumes:
 
 networks:
   camunda:
+    name: camunda
 
 configs:
   connectors-config:

--- a/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
@@ -459,5 +459,8 @@ networks:
   # It is also part of the camunda-platform network to communicate with the platform components like Orchestration to run
   # processes or Identity to log in.
   camunda-platform:
+    name: camunda-platform
   identity-network:
+    name: identity-network
   web-modeler:
+    name: web-modeler

--- a/docker-compose/versions/camunda-8.8/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-web-modeler.yaml
@@ -252,8 +252,11 @@ services:
 
 networks:
   camunda-platform:
+    name: camunda-platform
   identity-network:
+    name: identity-network
   web-modeler:
+    name: web-modeler
 
 volumes:
   postgres:

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -92,6 +92,7 @@ volumes:
 
 networks:
   camunda:
+    name: camunda
 
 configs:
   connectors-config:

--- a/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
@@ -439,5 +439,8 @@ networks:
   # It is also part of the camunda-platform network to communicate with the platform components like Orchestration to run
   # processes or Identity to log in.
   camunda-platform:
+    name: camunda-platform
   identity-network:
+    name: identity-network
   web-modeler:
+    name: web-modeler

--- a/docker-compose/versions/camunda-8.9/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose-web-modeler.yaml
@@ -221,8 +221,11 @@ services:
 
 networks:
   camunda-platform:
+    name: camunda-platform
   identity-network:
+    name: identity-network
   web-modeler:
+    name: web-modeler
 
 volumes:
   postgres:

--- a/docker-compose/versions/camunda-8.9/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose.yaml
@@ -81,6 +81,7 @@ volumes:
 
 networks:
   camunda:
+    name: camunda
 
 configs:
   connectors-config:


### PR DESCRIPTION
Closes #314

Adds explicit `name:` fields to the network entries in all default
docker-compose files for 8.8, 8.9, and 8.10 so external containers
can join the network and resolve Camunda hostnames via predictable,
non-Compose-prefixed names.

- `docker-compose.yaml`: network `camunda`
- `docker-compose-full.yaml` + `docker-compose-web-modeler.yaml`:
  networks `camunda-platform`, `identity-network`, `web-modeler`