### PR TITLE
fix(ci): pin actions/add-to-project to commit SHA

### DIFF
--- a/.github/workflows/add-new-issue.yml
+++ b/.github/workflows/add-new-issue.yml
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
       
       - name: Add to Distribution Team project
-        uses: actions/add-to-project@v2.0.0
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/camunda/projects/33
           github-token: '${{ steps.generate-github-token.outputs.token }}'


### PR DESCRIPTION
## Summary

- Pins `actions/add-to-project@v2.0.0` to its commit SHA (`5afcf98`) instead of the mutable version tag
- Follow-up to #417, which bumped the action to v2 but left it on a floating tag

Mutable tags can be force-pushed to point at arbitrary code. All other actions in this repo (e.g. `vault-action`, `create-github-app-token`) are already SHA-pinned — this brings `add-to-project` in line with that convention.

## Test plan

- [ ] Verify the `add-new-issue` workflow fires correctly on next issue open/transfer

🤖 Generated with [Claude Code](https://claude.com/claude-code)