### PR TITLE
docs: add CLAUDE.md, AGENTS.md, and docs/ for Claude Code guidance

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,84 @@
+# Agent Instructions — CI/CD Architecture
+
+This file covers the CI/CD workflows and release model for `camunda/camunda-distributions`.
+For practical commands and rules, read `AGENTS.md` at the repo root.
+
+## Repository Structure
+
+```
+docker-compose/
+  versions/
+    camunda-8.4/ … camunda-8.10/   # Per-version compose configs (see docs/version-architecture.md)
+  test/
+    e2e/                            # Shared Playwright tests (used by 8.4–8.7)
+
+.github/
+  actions/
+    install-playwright/             # Composite: sets up Node 24 + Playwright (Chromium)
+    generate-versions-matrix/       # Composite: detects changed versions → GHA matrix excludes
+  config/
+    renovatebot/                    # Renovate override configs
+  workflows/
+    docker-compose-test-e2e-template.yaml    # Reusable: spin up compose, run Playwright
+    docker-compose-test-e2e-full-setup.yaml  # Caller: matrix across all versions
+    docker-compose-release-template.yaml     # Reusable: package + publish one version
+    docker-compose-release.yaml              # Caller: rolling release matrix
+    renovatebot-config-check.yaml            # Validates Renovate config on PRs
+```
+
+## Workflows
+
+### E2E Tests (`docker-compose-test-e2e-full-setup.yaml`)
+
+Triggers on push to `main` or PR touching `docker-compose/versions/**`.
+
+- **init job**: Runs `generate-versions-matrix` to build an exclude list of unchanged versions (skip-if-unchanged optimization).
+- **exec job**: Fans out across all version matrix entries; passes compose args, e2e flag, and test directory to the reusable template.
+- Each matrix entry specifies: `camunda-version`, `main-compose-args`, `e2e-test-enabled`, optional `e2e-test-directory`.
+- E2E tests default to `docker-compose/test/e2e`; versions 8.8+ use their own `docker-compose/versions/camunda-X.Y/tests/`.
+- Matrix entries marked ⭐ are the primary configs per version (full-stack with e2e enabled).
+
+### E2E Test Template (`docker-compose-test-e2e-template.yaml`)
+
+Reusable workflow called by the full-setup. Steps:
+1. Checkout repo.
+2. `install-playwright` composite action (Node 24, npm cache, Playwright Chromium).
+3. Start Docker Compose services.
+4. Wait for health checks.
+5. Run `npx playwright test` with configured args.
+6. Upload HTML report as artifact (30-day retention).
+
+Playwright config: Chromium only in CI (`retries: 2`, `workers: 1`).
+
+### Release (`docker-compose-release.yaml`)
+
+Triggers on push to `main` touching `docker-compose/versions/**`, or manual `workflow_dispatch` with `release-all` flag.
+
+- Rolling release model: each Camunda minor version has exactly one release artifact (no versioned tags).
+- **init job**: Generates changed-versions matrix (or all versions if `release-all=true`).
+- **exec job**: `max-parallel: 1` — releases versions sequentially in order (8.4 → 8.10).
+- Uses HashiCorp Vault for Docker registry credentials (DockerHub + `registry.camunda.cloud`).
+
+### `generate-versions-matrix` Action
+
+Located in `.github/actions/generate-versions-matrix/`.
+
+- Compares changed files against `docker-compose/versions/camunda-8.*` paths.
+- Outputs `unchanged` (JSON array of matrix excludes) and `should-run` (bool).
+- Used by both test and release workflows to skip unaffected versions on PRs.
+
+## Renovate
+
+Configured via `.github/renovate.json5` and per-component overrides in `.github/config/renovatebot/`.
+
+- **Patch-only automation**: Minor and major version bumps are disabled by default — only patches are auto-merged.
+- **Excluded versions**: 8.0, 8.1, 8.2 are excluded from all updates.
+- **Semantic commits enforced**: `deps(docker-compose)` or `deps(github-actions)` scope.
+- Docker image updates and GitHub Actions updates are managed separately.
+
+## Conventions
+
+- All secrets via HashiCorp Vault — no GitHub Secrets, no hardcoded values.
+- Reusable workflows (`*-template.yaml`) are called via `uses:` with `secrets: inherit`.
+- Artifact retention: 30 days for Playwright HTML reports.
+- `cancel-in-progress: true` on all workflow concurrency groups.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# Agent Instructions
+
+You are working on the **Camunda 8 Self-Managed Distributions** repository. It hosts Docker Compose configurations for all actively supported Camunda 8 releases (8.4–8.10), along with Playwright E2E tests and CI/CD automation.
+
+Use this file as the practical guide. For CI/CD and workflow architecture, also read `.github/AGENTS.md`.
+
+## Critical Rules
+
+- NEVER assume Docker Compose configs are identical across versions — always check the target version directory first.
+- NEVER edit `.env` files to add real credentials — they are templates; use environment variable exports for local testing.
+- ALWAYS open a GitHub issue before submitting a PR (required by contributing guidelines).
+- ALWAYS use Conventional Commits for PR titles and commit messages.
+- NEVER create a PR that touches multiple Camunda versions unless the change is truly cross-cutting (e.g., a shared workflow fix).
+
+## Quick Start
+
+- Identify the target Camunda version before editing (`docker-compose/versions/camunda-X.Y/`).
+- Keep changes version-scoped; the release workflow handles each version independently.
+- Read `STATE.md` at repo root if it exists (session continuity file, gitignored).
+
+## Docker Compose Commands
+
+```bash
+# Start a version (lightweight: Zeebe + Operate + Tasklist + Connectors, H2 storage)
+cd docker-compose/versions/camunda-8.10
+docker compose -f docker-compose.yaml up -d
+
+# Start with full stack (Optimize, Identity/Keycloak, Web Modeler, Console)
+docker compose -f docker-compose-full.yaml up -d
+
+# Start Web Modeler standalone
+docker compose -f docker-compose-web-modeler.yaml up -d
+
+# View logs for a specific service
+docker compose logs orchestration -f
+
+# Tear down
+docker compose down
+
+# Tear down including volumes
+docker compose down -v
+```
+
+### Switching Secondary Storage (8.10+)
+
+```bash
+# Set config file before starting (H2 is default)
+export ORCHESTRATION_CONFIG_FILE=application-postgresql.yaml
+docker compose up -d
+
+# Available configs in configuration/:
+# application-h2.yaml (default)
+# application-mysql.yaml
+# application-mariadb.yaml
+# application-postgresql.yaml
+# application-mssql.yaml
+# application-oracle.yaml
+```
+
+For MySQL/MariaDB/MSSQL/Oracle, copy the vendor JDBC `.jar` into `driver-lib/` before starting. PostgreSQL and H2 drivers are bundled.
+
+## E2E Test Commands
+
+```bash
+# From the shared test directory
+cd docker-compose/test/e2e
+npm ci
+npx playwright install --with-deps chromium
+
+# Run all tests
+npx playwright test
+
+# Run with visible browser
+npx playwright test --headed
+
+# Debug a specific test
+npx playwright test --debug
+
+# View HTML report after a run
+npx playwright show-report
+```
+
+Version-specific tests live in `docker-compose/versions/camunda-X.Y/tests/` and use the same commands.
+
+## Version Architecture
+
+See `docs/version-architecture.md` for a detailed breakdown. Key differences:
+
+| Versions  | Compose flavors                  | ES bundled | Secondary storage |
+|-----------|----------------------------------|------------|-------------------|
+| 8.4–8.7   | `docker-compose.yaml`, `-core`, `-web-modeler` | Yes | Elasticsearch |
+| 8.8–8.9   | `docker-compose.yaml`, `-full`, `-web-modeler` | Yes | Elasticsearch |
+| 8.10+     | `docker-compose.yaml`, `-full`, `-web-modeler` | **No** | H2 (default), external DB |
+
+- **8.8+**: `docker-compose.yaml` is the lightweight setup (no Identity/Optimize/Web Modeler). `-full` is the complete stack.
+- **8.10+**: Elasticsearch is no longer bundled. `docker-compose-full.yaml` expects an external ES endpoint via `.env`.
+
+## State File
+
+Use `STATE.md` (repo root, gitignored) to persist session context across conversations.
+
+**On session start:** Read `STATE.md` if it exists.
+
+**During work:** Update whenever you complete a task, make a key decision, or discover something important.
+
+**Format:**
+
+```markdown
+## Goal
+One-line summary of what we are working on.
+
+## Instructions
+Constraints or standing orders from the user that apply across sessions.
+
+## Discoveries
+Key findings, gotchas, and decisions made during investigation.
+
+## Accomplished
+Numbered list of completed items.
+
+## Not Yet Done
+Numbered list of remaining items, in priority order.
+
+## Relevant Files
+Files central to the current task, with brief annotations.
+```
+
+## Commit and Branch Conventions
+
+- Branches: `issueId-description` (e.g., `423-fix-8-10-postgres-config`)
+- Commit/PR titles: Conventional Commits format
+- Common types: `feat`, `fix`, `docs`, `ci`, `deps`, `chore`
+- Scope: `docker-compose` for compose file changes, `github-actions` for workflow changes
+- Examples:
+  - `fix(docker-compose): correct connector secret key for 8.10`
+  - `deps(docker-compose): update camunda/operate docker tag to v8.10.1`
+  - `ci: add matrix entry for 8.10 full-setup e2e`
+- **NEVER create merge commits.** Use `git rebase origin/main` to update branches.
+
+## Additional Agent Context
+
+- `CLAUDE.md` — thin redirect for Claude Code (points to this file)
+- `.github/AGENTS.md` — CI/CD workflow architecture, release model, matrix generation
+- `docs/index.md` — repository overview and purpose
+- `docs/version-architecture.md` — per-version compose flavors, storage backends, key changes
+- `docs/e2e-testing.md` — E2E test layout, how to run locally, CI test matrix
+- `STATE.md` — session continuity (gitignored, read on session start)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,6 @@
 
 You are working on the **Camunda 8 Self-Managed Distributions** repository. It hosts Docker Compose configurations for all actively supported Camunda 8 releases (8.4–8.10), along with Playwright E2E tests and CI/CD automation.
 
-Use this file as the practical guide. For CI/CD and workflow architecture, also read `.github/AGENTS.md`.
-
 ## Critical Rules
 
 - NEVER assume Docker Compose configs are identical across versions — always check the target version directory first.
@@ -11,6 +9,7 @@ Use this file as the practical guide. For CI/CD and workflow architecture, also 
 - ALWAYS open a GitHub issue before submitting a PR (required by contributing guidelines).
 - ALWAYS use Conventional Commits for PR titles and commit messages.
 - NEVER create a PR that touches multiple Camunda versions unless the change is truly cross-cutting (e.g., a shared workflow fix).
+- NEVER create merge commits. Use `git rebase origin/main` to update branches.
 
 ## Quick Start
 
@@ -18,130 +17,32 @@ Use this file as the practical guide. For CI/CD and workflow architecture, also 
 - Keep changes version-scoped; the release workflow handles each version independently.
 - Read `STATE.md` at repo root if it exists (session continuity file, gitignored).
 
-## Docker Compose Commands
+## Commit and Branch Conventions
 
-```bash
-# Start a version (lightweight: Zeebe + Operate + Tasklist + Connectors, H2 storage)
-cd docker-compose/versions/camunda-8.10
-docker compose -f docker-compose.yaml up -d
-
-# Start with full stack (Optimize, Identity/Keycloak, Web Modeler, Console)
-docker compose -f docker-compose-full.yaml up -d
-
-# Start Web Modeler standalone
-docker compose -f docker-compose-web-modeler.yaml up -d
-
-# View logs for a specific service
-docker compose logs orchestration -f
-
-# Tear down
-docker compose down
-
-# Tear down including volumes
-docker compose down -v
-```
-
-### Switching Secondary Storage (8.10+)
-
-```bash
-# Set config file before starting (H2 is default)
-export ORCHESTRATION_CONFIG_FILE=application-postgresql.yaml
-docker compose up -d
-
-# Available configs in configuration/:
-# application-h2.yaml (default)
-# application-mysql.yaml
-# application-mariadb.yaml
-# application-postgresql.yaml
-# application-mssql.yaml
-# application-oracle.yaml
-```
-
-For MySQL/MariaDB/MSSQL/Oracle, copy the vendor JDBC `.jar` into `driver-lib/` before starting. PostgreSQL and H2 drivers are bundled.
-
-## E2E Test Commands
-
-```bash
-# From the shared test directory
-cd docker-compose/test/e2e
-npm ci
-npx playwright install --with-deps chromium
-
-# Run all tests
-npx playwright test
-
-# Run with visible browser
-npx playwright test --headed
-
-# Debug a specific test
-npx playwright test --debug
-
-# View HTML report after a run
-npx playwright show-report
-```
-
-Version-specific tests live in `docker-compose/versions/camunda-X.Y/tests/` and use the same commands.
-
-## Version Architecture
-
-See `docs/version-architecture.md` for a detailed breakdown. Key differences:
-
-| Versions  | Compose flavors                  | ES bundled | Secondary storage |
-|-----------|----------------------------------|------------|-------------------|
-| 8.4–8.7   | `docker-compose.yaml`, `-core`, `-web-modeler` | Yes | Elasticsearch |
-| 8.8–8.9   | `docker-compose.yaml`, `-full`, `-web-modeler` | Yes | Elasticsearch |
-| 8.10+     | `docker-compose.yaml`, `-full`, `-web-modeler` | **No** | H2 (default), external DB |
-
-- **8.8+**: `docker-compose.yaml` is the lightweight setup (no Identity/Optimize/Web Modeler). `-full` is the complete stack.
-- **8.10+**: Elasticsearch is no longer bundled. `docker-compose-full.yaml` expects an external ES endpoint via `.env`.
+- Branches: `issueId-description` (e.g., `423-fix-8-10-postgres-config`)
+- Commit/PR titles: Conventional Commits — `<type>(<scope>): <description>`
+- Common types: `feat`, `fix`, `docs`, `ci`, `deps`, `chore`
+- Scope: `docker-compose` for compose file changes, `github-actions` for workflow changes
 
 ## State File
 
 Use `STATE.md` (repo root, gitignored) to persist session context across conversations.
 
-**On session start:** Read `STATE.md` if it exists.
-
-**During work:** Update whenever you complete a task, make a key decision, or discover something important.
-
-**Format:**
+**On session start:** Read `STATE.md` if it exists. **During work:** Update whenever you complete a task, make a key decision, or discover something important.
 
 ```markdown
 ## Goal
-One-line summary of what we are working on.
-
 ## Instructions
-Constraints or standing orders from the user that apply across sessions.
-
 ## Discoveries
-Key findings, gotchas, and decisions made during investigation.
-
 ## Accomplished
-Numbered list of completed items.
-
 ## Not Yet Done
-Numbered list of remaining items, in priority order.
-
 ## Relevant Files
-Files central to the current task, with brief annotations.
 ```
 
-## Commit and Branch Conventions
+## Reference Docs
 
-- Branches: `issueId-description` (e.g., `423-fix-8-10-postgres-config`)
-- Commit/PR titles: Conventional Commits format
-- Common types: `feat`, `fix`, `docs`, `ci`, `deps`, `chore`
-- Scope: `docker-compose` for compose file changes, `github-actions` for workflow changes
-- Examples:
-  - `fix(docker-compose): correct connector secret key for 8.10`
-  - `deps(docker-compose): update camunda/operate docker tag to v8.10.1`
-  - `ci: add matrix entry for 8.10 full-setup e2e`
-- **NEVER create merge commits.** Use `git rebase origin/main` to update branches.
-
-## Additional Agent Context
-
-- `CLAUDE.md` — thin redirect for Claude Code (points to this file)
-- `.github/AGENTS.md` — CI/CD workflow architecture, release model, matrix generation
-- `docs/index.md` — repository overview and purpose
-- `docs/version-architecture.md` — per-version compose flavors, storage backends, key changes
-- `docs/e2e-testing.md` — E2E test layout, how to run locally, CI test matrix
-- `STATE.md` — session continuity (gitignored, read on session start)
+- `docs/index.md` — repository overview and directory map
+- `docs/commands.md` — Docker Compose and E2E test commands
+- `docs/version-architecture.md` — per-version compose flavors, storage backends, 8.10 ES changes
+- `docs/e2e-testing.md` — test layout, running locally, CI matrix
+- `docs/ci-workflows.md` — CI/CD workflow architecture, release model, Renovate config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with this repository.
+Read `AGENTS.md` for commands and rules, and `.github/AGENTS.md` for CI/CD architecture.
+
+@AGENTS.md

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -1,14 +1,15 @@
-# Agent Instructions — CI/CD Architecture
+---
+title: CI/CD Workflows
+---
 
-This file covers the CI/CD workflows and release model for `camunda/camunda-distributions`.
-For practical commands and rules, read `AGENTS.md` at the repo root.
+# CI/CD Workflows
 
 ## Repository Structure
 
 ```
 docker-compose/
   versions/
-    camunda-8.4/ … camunda-8.10/   # Per-version compose configs (see docs/version-architecture.md)
+    camunda-8.4/ … camunda-8.10/   # Per-version compose configs
   test/
     e2e/                            # Shared Playwright tests (used by 8.4–8.7)
 
@@ -71,7 +72,7 @@ Located in `.github/actions/generate-versions-matrix/`.
 
 Configured via `.github/renovate.json5` and per-component overrides in `.github/config/renovatebot/`.
 
-- **Patch-only automation**: Minor and major version bumps are disabled by default — only patches are auto-merged.
+- **Patch-only automation**: Minor and major version bumps are disabled — only patches are auto-merged.
 - **Excluded versions**: 8.0, 8.1, 8.2 are excluded from all updates.
 - **Semantic commits enforced**: `deps(docker-compose)` or `deps(github-actions)` scope.
 - Docker image updates and GitHub Actions updates are managed separately.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,69 @@
+---
+title: Commands
+---
+
+# Commands
+
+## Docker Compose
+
+```bash
+# Start lightweight setup (Zeebe + Operate + Tasklist + Connectors, H2 storage)
+cd docker-compose/versions/camunda-8.10
+docker compose -f docker-compose.yaml up -d
+
+# Start full stack (Optimize, Identity/Keycloak, Web Modeler, Console)
+docker compose -f docker-compose-full.yaml up -d
+
+# Start Web Modeler standalone
+docker compose -f docker-compose-web-modeler.yaml up -d
+
+# View logs for a specific service
+docker compose logs orchestration -f
+
+# Tear down
+docker compose down
+
+# Tear down including volumes
+docker compose down -v
+```
+
+### Switching Secondary Storage (8.10+)
+
+```bash
+# Set config file before starting (H2 is default)
+export ORCHESTRATION_CONFIG_FILE=application-postgresql.yaml
+docker compose up -d
+
+# Available configs in configuration/:
+# application-h2.yaml (default)
+# application-mysql.yaml
+# application-mariadb.yaml
+# application-postgresql.yaml
+# application-mssql.yaml
+# application-oracle.yaml
+```
+
+For MySQL/MariaDB/MSSQL/Oracle, copy the vendor JDBC `.jar` into `driver-lib/` before starting. PostgreSQL and H2 drivers are bundled.
+
+## E2E Tests
+
+```bash
+# From the shared test directory (8.4–8.7)
+cd docker-compose/test/e2e
+npm ci
+npx playwright install --with-deps chromium
+
+# Run all tests
+npx playwright test
+
+# Run with visible browser
+npx playwright test --headed
+
+# Debug a specific test
+npx playwright test --debug
+
+# View HTML report after a run
+npx playwright show-report
+```
+
+Version-specific tests live in `docker-compose/versions/camunda-X.Y/tests/` and use the same commands.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,54 @@
+---
+title: E2E Testing
+---
+
+# E2E Testing
+
+Playwright tests validate that each Docker Compose setup starts correctly and that the web UIs are accessible. Tests run in CI for every version on push to `main` or on PRs that touch `docker-compose/versions/**`.
+
+## Test Layout
+
+| Path | Used by versions | Purpose |
+|------|-----------------|---------|
+| `docker-compose/test/e2e/` | 8.4–8.7 (and 8.8–8.9 lightweight) | Shared tests: login flows for Operate, Tasklist |
+| `docker-compose/versions/camunda-8.8/tests/` | 8.8 full-stack | Full-stack tests including Optimize, Web Modeler, Console |
+| `docker-compose/versions/camunda-8.9/tests/` | 8.9 full-stack | Same as 8.8 |
+
+Version-specific test directories are used when `e2e-test-directory` is specified in the CI matrix (see `.github/workflows/docker-compose-test-e2e-full-setup.yaml`).
+
+## Running Locally
+
+```bash
+# 1. Start the compose stack you want to test
+cd docker-compose/versions/camunda-8.9
+docker compose -f docker-compose-full.yaml up -d
+
+# 2. Wait for services to be healthy
+docker compose ps   # all services should show "healthy"
+
+# 3. Run the version-specific tests
+cd tests
+npm ci
+npx playwright install --with-deps chromium
+npx playwright test
+
+# Or run the shared tests
+cd ../../../test/e2e
+npm ci
+npx playwright install --with-deps chromium
+npx playwright test
+```
+
+## CI Configuration
+
+- **Browser**: Chromium only (Firefox and Safari are commented out to reduce CI time).
+- **Retries**: 2 retries in CI, 0 locally.
+- **Workers**: 1 (no parallel execution) in CI.
+- **Reports**: HTML artifacts uploaded with 30-day retention.
+- **Test gate**: Only versions with `e2e-test-enabled: true` in the matrix actually run Playwright. Others only validate that compose starts and becomes healthy.
+
+## Adding Tests for a New Version
+
+1. Copy `tests/` from the nearest existing version into the new version directory.
+2. Add a matrix entry in `.github/workflows/docker-compose-test-e2e-full-setup.yaml` with `e2e-test-enabled: true` and `e2e-test-directory: docker-compose/versions/camunda-X.Y/tests`.
+3. Run locally against the new version to validate before pushing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,10 @@ This repository contains the official Camunda 8 Self-Managed distributions for D
 
 | Page | Description |
 |------|-------------|
+| [Commands](./commands.md) | Docker Compose and E2E test commands |
 | [Version Architecture](./version-architecture.md) | Per-version compose flavors, storage backends, and key changes |
 | [E2E Testing](./e2e-testing.md) | Playwright test layout, running locally, CI matrix |
+| [CI/CD Workflows](./ci-workflows.md) | Workflow architecture, release model, Renovate config |
 
 ## Repository Purpose
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,29 @@
+---
+title: Overview
+---
+
+# Camunda Distributions — Developer Docs
+
+This repository contains the official Camunda 8 Self-Managed distributions for Docker Compose. It is a development and testing repository — end users should use the [official documentation](https://docs.camunda.io/docs/self-managed/about-self-managed/).
+
+## Topics
+
+| Page | Description |
+|------|-------------|
+| [Version Architecture](./version-architecture.md) | Per-version compose flavors, storage backends, and key changes |
+| [E2E Testing](./e2e-testing.md) | Playwright test layout, running locally, CI matrix |
+
+## Repository Purpose
+
+- Provide Docker Compose setups for local development across all actively supported Camunda 8 minor versions (currently 8.4–8.10).
+- Validate those setups with Playwright E2E tests in CI.
+- Publish rolling releases (one artifact per minor version) to the Camunda registry on every merge to `main`.
+
+## Key Directories
+
+| Path | Description |
+|------|-------------|
+| `docker-compose/versions/camunda-X.Y/` | Version-specific compose files, env, and config |
+| `docker-compose/test/e2e/` | Shared Playwright tests (8.4–8.7 and earlier 8.8 variants) |
+| `.github/workflows/` | CI/CD: E2E tests + rolling release |
+| `.github/actions/` | Composite actions: Playwright setup, matrix generation |

--- a/docs/version-architecture.md
+++ b/docs/version-architecture.md
@@ -1,0 +1,80 @@
+---
+title: Version Architecture
+---
+
+# Version Architecture
+
+Each supported Camunda version lives in its own directory under `docker-compose/versions/camunda-X.Y/`. While the directory layout is consistent, there are meaningful differences in compose flavors and storage backends across versions.
+
+## Compose Flavors by Version
+
+| Version | `docker-compose.yaml` | `docker-compose-full.yaml` | `-web-modeler.yaml` | `-core.yaml` |
+|---------|----------------------|----------------------------|---------------------|--------------|
+| 8.4–8.7 | Full stack (includes Identity, Optimize, Web Modeler) | — | Standalone Web Modeler | Identity-disabled variant |
+| 8.8–8.9 | Lightweight (Zeebe + Operate + Tasklist + Connectors, no Identity/Optimize) | Full stack | Standalone Web Modeler | — |
+| 8.10+   | Lightweight (H2 default, no ES) | Full stack (requires external ES) | Standalone Web Modeler | — |
+
+**Key shift at 8.8:** `docker-compose.yaml` became the lightweight setup. To get the full stack (Identity, Optimize, Web Modeler, Console), use `docker-compose-full.yaml`.
+
+## Elasticsearch Changes at 8.10
+
+Elasticsearch is no longer bundled in any Docker Compose file for 8.10+.
+
+- `docker-compose.yaml` defaults to H2 secondary storage (no ES dependency).
+- `docker-compose-full.yaml` still supports ES but requires an external endpoint configured via `.env`:
+  ```
+  ELASTICSEARCH_URL=http://localhost:9200
+  ELASTICSEARCH_HOST=localhost
+  ELASTICSEARCH_PORT=9200
+  ELASTICSEARCH_CLUSTER_NAME=elasticsearch
+  ```
+
+## Secondary Storage (8.10+)
+
+The Orchestration container mounts `configuration/<file>.yaml` as its application config. Set `ORCHESTRATION_CONFIG_FILE` in `.env` to switch backends:
+
+| Config file | Database | Drivers bundled |
+|------------|----------|-----------------|
+| `application-h2.yaml` | H2 (default, file-based) | Yes |
+| `application-postgresql.yaml` | PostgreSQL | Yes |
+| `application-mysql.yaml` | MySQL | No — drop `.jar` in `driver-lib/` |
+| `application-mariadb.yaml` | MariaDB | No — drop `.jar` in `driver-lib/` |
+| `application-mssql.yaml` | SQL Server | No — drop `.jar` in `driver-lib/` |
+| `application-oracle.yaml` | Oracle | No — drop `.jar` in `driver-lib/` |
+
+H2 data files are stored in `camunda-data/` (gitignored).
+
+## Version Directory Layout
+
+```
+docker-compose/versions/camunda-X.Y/
+  docker-compose.yaml              # Primary compose file
+  docker-compose-full.yaml         # Full stack (8.8+)
+  docker-compose-web-modeler.yaml  # Web Modeler standalone
+  .env                             # Image versions + runtime config (template, not for real secrets)
+  connector-secrets.txt            # Connector environment variables
+  configuration/                   # Database-specific application.yaml files (8.10+)
+  driver-lib/                      # Drop vendor JDBC jars here (gitignored content)
+  camunda-data/                    # Runtime H2 data (gitignored)
+  tests/                           # Version-specific Playwright tests (8.8+)
+  .orchestration/application.yaml  # Zeebe/Operate/Tasklist config
+  .connectors/application.yaml     # Connectors bundle config
+  .identity/application.yaml       # Identity/Keycloak config
+  .console/application.yaml        # Console config
+  .optimize/application.yaml       # Optimize config
+```
+
+## Authentication
+
+The full-stack setup uses Keycloak for OIDC. Keycloak runs on port `18080`, using `host.docker.internal` for internal service-to-service communication. Default credentials are in `.env` — do not commit real secrets there.
+
+## Port Reference
+
+| Port  | Service          |
+|-------|------------------|
+| 8080  | Orchestration REST API |
+| 26500 | Orchestration gRPC |
+| 9600  | Management/actuator |
+| 8086  | Connectors |
+| 18080 | Keycloak |
+| 5432  | PostgreSQL (when used) |


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` (thin pointer, matches `camunda-platform-helm` pattern)
- Adds `AGENTS.md` with practical commands, critical rules, and session-continuity (`STATE.md`) guidance
- Adds `.github/AGENTS.md` covering CI/CD workflow architecture, release model, and Renovate config
- Adds `docs/` with `index.md`, `version-architecture.md` (per-version compose flavors, 8.10 ES removal, storage backends), and `e2e-testing.md` (test layout, local run, CI matrix)

## Test plan

- [ ] Verify `CLAUDE.md` `@AGENTS.md` include resolves correctly in Claude Code
- [ ] Check that commands in `AGENTS.md` match actual repo structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)