### PR TITLE
ci(github-actions): cache Playwright binaries and add job timeout

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -19,10 +19,17 @@ runs:
         restore-keys: |
           ${{ runner.os }}-node-
 
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      id: playwright-cache
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ inputs.browsers }}-${{ hashFiles('**/package-lock.json') }}
+
     - name: Check cache hit
       shell: bash
       run: |
-        echo "Cache hit: ${{ steps.npm-cache.outputs.cache-hit }}"
+        echo "npm cache hit: ${{ steps.npm-cache.outputs.cache-hit }}"
+        echo "playwright cache hit: ${{ steps.playwright-cache.outputs.cache-hit }}"
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -37,4 +44,9 @@ runs:
     - name: Install Playwright browsers
       working-directory: ${{ inputs.working-directory }}
       shell: bash
-      run: npx playwright install --with-deps ${{ inputs.browsers }}
+      run: |
+        if [[ "${{ steps.playwright-cache.outputs.cache-hit }}" == "true" ]]; then
+          npx playwright install-deps ${{ inputs.browsers }}
+        else
+          npx playwright install --with-deps ${{ inputs.browsers }}
+        fi

--- a/.github/workflows/docker-compose-test-e2e-template.yaml
+++ b/.github/workflows/docker-compose-test-e2e-template.yaml
@@ -36,6 +36,7 @@ jobs:
     # if: contains(inputs.changed-versions, inputs.camunda-version)
     name: Run
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       #
       # Init.


### PR DESCRIPTION
## Summary

- Cache `~/.cache/ms-playwright` in `install-playwright` action (keyed on OS + browser + `package-lock.json` hash) — skips multi-hundred-MB browser download on cache hit
- On cache hit: run `install-deps` only (OS packages, fast); on cache miss: run full `install --with-deps`
- Add `timeout-minutes: 30` to E2E template job — previously no limit, causing stuck Playwright installs to run for the full 6h GHA default before cancelling

## Context

`Camunda 8.9 ⭐` E2E jobs were hanging at `Install Playwright` for 6 hours before GHA cancelled them. Other variants (`Identity Disabled`, `Web Modeler Standalone`) skip Playwright entirely and pass. The browser binary download was the bottleneck — no cache, no timeout.

## Test plan

- [ ] Verify first run after merge downloads browsers and populates cache
- [ ] Verify subsequent runs use cache and complete `Install Playwright` in seconds
- [ ] Verify hung jobs now fail fast at 30 min instead of 6h

🤖 Generated with [Claude Code](https://claude.com/claude-code)