### PR TITLE
ci: enable renovate auto-merge and flaky CI retry

### DIFF
--- a/.github/config/renovatebot/renovate-main.json5
+++ b/.github/config/renovatebot/renovate-main.json5
@@ -8,6 +8,21 @@
   patch: {
     enabled: true,
   },
+  packageRules: [
+    {
+      description: "Auto-merge non-major updates once CI passes.",
+      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+      automerge: true,
+      platformAutomerge: false,
+      automergeStrategy: "squash",
+      addLabels: ["automerge"],
+    },
+    {
+      description: "Never auto-merge alpha release candidates.",
+      matchNewValue: "/.*alpha[0-9]*-rc[0-9]*/",
+      automerge: false,
+    },
+  ],
   hostRules: [
     {
       hostType: "docker",

--- a/.github/workflows/renovate-ci-retry.yaml
+++ b/.github/workflows/renovate-ci-retry.yaml
@@ -1,0 +1,33 @@
+# type: Automation
+# owner: @camunda/distribution-team
+---
+# Re-runs failed E2E jobs for Renovate PRs to absorb flaky failures, so a green
+# run lets the PR auto-merge. Capped at 3 attempts per run.
+name: Renovate - CI Retry
+
+on:
+  workflow_run:
+    workflows: ["Docker Compose | Test - E2E - Full Setup"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retry:
+    name: Re-run failed jobs
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'renovate/') &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Re-run failed jobs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          echo "Re-running failed jobs for run ${RUN_ID} (attempt ${ATTEMPT})."
+          gh run rerun "$RUN_ID" --failed --repo "${{ github.repository }}"


### PR DESCRIPTION
## Which problem does the PR fix?

Closes #448

## What's in this PR?

- `renovate-main.json5`: auto-merge (squash, `platformAutomerge: false`) for non-major updates once CI is green; labels them `automerge`; keeps alpha release candidates non-automerged.
- `renovate-ci-retry.yaml`: re-runs failed E2E jobs on `renovate/*` branches (capped at 3 attempts) so a flaky failure self-heals.

The `main` ruleset requires one approval. As in camunda-platform-helm, this is provided by the Mend **Renovate Approve** app (`renovate-approve[bot]`) — it must be enabled on this repository.
