### PR TITLE
ci: use GitHub native auto-merge for renovate PRs

### DIFF
--- a/.github/config/renovatebot/renovate-github-actions.json5
+++ b/.github/config/renovatebot/renovate-github-actions.json5
@@ -8,5 +8,9 @@
       matchManagers: ["github-actions"],
       schedule: ["every weekend"],
     },
+    {
+      matchDepNames: ["camunda/team-distribution"],
+      enabled: false,
+    },
   ],
 }

--- a/.github/config/renovatebot/renovate-main.json5
+++ b/.github/config/renovatebot/renovate-main.json5
@@ -13,7 +13,7 @@
       description: "Auto-merge non-major updates once CI passes.",
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],
       automerge: true,
-      platformAutomerge: false,
+      platformAutomerge: true,
       automergeStrategy: "squash",
       addLabels: ["automerge"],
     },

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -1,0 +1,59 @@
+# type: Automation
+# owner: @camunda/distribution-team
+---
+# Single stable required status check for GitHub native auto-merge. The E2E
+# matrix job names are version-dynamic and its workflow is path-filtered, so
+# neither can be required directly. This gate posts one fixed context
+# ("Merge Gate / gate") on every PR:
+#   - workflow_run: mirrors the E2E workflow conclusion (re-fires on CI-retry).
+#   - pull_request: for PRs that skip E2E, passes when no E2E-relevant path
+#     changed; for mixed PRs it fails so the workflow_run result stays
+#     authoritative and nothing merges before E2E.
+name: Merge Gate
+
+on:
+  workflow_run:
+    workflows: ["Docker Compose | Test - E2E - Full Setup"]
+    types: [completed]
+  pull_request:
+    paths-ignore:
+      - docker-compose/versions/**
+      - .github/workflows/docker-compose-test-e2e-template.yaml
+      - .github/workflows/docker-compose-test-e2e-full-setup.yaml
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Mirror E2E result
+        if: github.event_name == 'workflow_run'
+        run: |
+          conclusion="${{ github.event.workflow_run.conclusion }}"
+          echo "E2E workflow concluded: ${conclusion}"
+          [ "${conclusion}" = "success" ] || { echo "::error::E2E did not succeed (${conclusion})"; exit 1; }
+
+      - name: Detect E2E-relevant changes
+        if: github.event_name == 'pull_request'
+        id: changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            e2e:
+              - docker-compose/versions/**
+              - .github/workflows/docker-compose-test-e2e-template.yaml
+              - .github/workflows/docker-compose-test-e2e-full-setup.yaml
+
+      - name: Gate on E2E relevance
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ "${{ steps.changes.outputs.e2e }}" = "true" ]; then
+            echo "::error::E2E-relevant paths changed; deferring to the E2E workflow result."
+            exit 1
+          fi
+          echo "No E2E-relevant paths changed; gate passes."


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #464.

### What's in this PR?

- `renovate-main.json5`: `platformAutomerge: false → true` — Renovate arms GitHub-native auto-merge so PRs merge the instant required checks pass, instead of waiting on the Mend cloud poll cycle. `automerge: true` stays as a fallback.
- `merge-gate.yaml` (new): one stable required status check, `Merge Gate / gate`. The E2E workflow is path-filtered and its matrix job names are version-dynamic, so neither can be required directly. This gate posts a fixed context on every PR — via `workflow_run` it mirrors the E2E conclusion (re-fires on CI-retry); via `pull_request` it passes PRs that skip E2E and defers mixed PRs to the E2E result so nothing merges before CI.
- `renovate-github-actions.json5`: disable the `camunda/team-distribution` dep — it is an internal repo whose github-digest cannot be resolved, which was raising a Dependency Dashboard warning.

The `platformAutomerge` flag is inert until an admin enables the repo **Allow auto-merge** setting and adds `Merge Gate / gate` as a required status check on the `main` ruleset.

### Checklist

- [ ] Tests
- [ ] Documentation