### PR TITLE
fix(docker-compose): mount orchestration data volume at /usr/local/camunda/data

### DIFF
--- a/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
@@ -57,7 +57,7 @@ services:
       retries: 5
       start_period: 30s
     volumes:
-      - orchestration:/usr/local/zeebe/data
+      - orchestration:/usr/local/camunda/data
       - camunda-data:/usr/local/camunda/camunda-data
       - "./.orchestration/application.yaml:/usr/local/camunda/config/application.yaml"
     networks:

--- a/docker-compose/versions/camunda-8.10/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       retries: 30
       start_period: 30s
     volumes:
-      - zeebe:/usr/local/zeebe/data
+      - camunda:/usr/local/camunda/data
       - camunda-data:/usr/local/camunda/camunda-data
       - ./driver-lib:/driver-lib:ro
     configs:
@@ -77,7 +77,7 @@ services:
         condition: service_healthy
 
 volumes:
-  zeebe:
+  camunda:
   camunda-data:
 
 networks:

--- a/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
@@ -49,7 +49,7 @@ services:
       retries: 5
       start_period: 30s
     volumes:
-      - orchestration:/usr/local/zeebe/data
+      - orchestration:/usr/local/camunda/data
       - "./.orchestration/application.yaml:/usr/local/camunda/config/application.yaml"
     networks:
       - camunda-platform

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       retries: 30
       start_period: 30s
     volumes:
-      - zeebe:/usr/local/zeebe/data
+      - camunda:/usr/local/camunda/data
     configs:
       - source: orchestration-config
         target: /usr/local/camunda/config/application.yaml
@@ -87,7 +87,7 @@ services:
       - camunda
 
 volumes:
-  zeebe:
+  camunda:
   elastic:
 
 networks:

--- a/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
@@ -56,7 +56,7 @@ services:
       retries: 5
       start_period: 30s
     volumes:
-      - orchestration:/usr/local/zeebe/data
+      - orchestration:/usr/local/camunda/data
       - camunda-data:/usr/local/camunda/camunda-data
       - "./.orchestration/application.yaml:/usr/local/camunda/config/application.yaml"
     networks:


### PR DESCRIPTION
Closes #467
Support: SUPPORT-33562 (https://jira.camunda.com/browse/SUPPORT-33562)
Incident: INC-6363

The orchestration named data volume was mounted at the legacy `/usr/local/zeebe/data`, but the `camunda/camunda` image writes primary Zeebe/RocksDB state to `/usr/local/camunda/data` (image `WorkingDir=/usr/local/camunda`, `VOLUME /usr/local/camunda/data`, default relative `data` dir). The real state landed on a throwaway anonymous volume and was wiped on `docker compose down`/`up`. #384 already fixed the 8.9 lightweight stack; this propagates the fix to the remaining affected files.

## Changes

| File | Change |
|---|---|
| `camunda-8.8/docker-compose.yaml` | `zeebe:/usr/local/zeebe/data` → `camunda:/usr/local/camunda/data` (+ rename top-level volume) |
| `camunda-8.8/docker-compose-full.yaml` | `orchestration:/usr/local/zeebe/data` → `orchestration:/usr/local/camunda/data` |
| `camunda-8.9/docker-compose-full.yaml` | `orchestration:/usr/local/zeebe/data` → `orchestration:/usr/local/camunda/data` |
| `camunda-8.10/docker-compose.yaml` | `zeebe:/usr/local/zeebe/data` → `camunda:/usr/local/camunda/data` (+ rename top-level volume) |
| `camunda-8.10/docker-compose-full.yaml` | `orchestration:/usr/local/zeebe/data` → `orchestration:/usr/local/camunda/data` |

No data migration needed — the misplaced named volume never held state.

## Verification (local, per file)

Reproduced against 8.8.30 / 8.9.11 / 8.10-SNAPSHOT. After the fix, on every stack `/usr/local/camunda/data` is backed by the **named** orchestration volume:

```
8.8 base  -> camunda-88_camunda        (raft-partition)
8.8 full  -> camunda-88_orchestration  (raft-partition)
8.9 full  -> camunda-89_orchestration  (raft-partition)
8.10 base -> camunda-810_camunda       (default)
8.10 full -> camunda-810_orchestration (default)
```

On 8.9 full, a sentinel written to `/usr/local/camunda/data` survives a `docker compose down` (no `-v`) + `up` cycle (before the fix it was wiped). `docker compose config` validates for all five files.
