### PR TITLE
ci: vendor self-contained PR activity Slack notifier

### DIFF
--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -3,41 +3,81 @@
 ---
 # PR Activity Slack Notifications
 #
-# Delegates to the canonical workflow in camunda/team-distribution.
-# See that repo for implementation details and the full input reference.
+# Sends a message to #team-distribution-github (via distro-bot) when:
+#   - A PR is opened or converted from draft to ready for review
+#   - A PR is merged
+#   - A PR is closed without merge
+#
+# Draft PRs and automerge Renovate PRs are skipped.
+#
+# Notification logic is implemented in scripts/notify-pr-activity (Go). This is a self-contained
+# copy of the canonical notifier in camunda/team-distribution — this repo is public and cannot call
+# an internal repo's reusable workflow, so the workflow and script are vendored here instead.
 #
 name: Notify - PR Activity
 
 on:
+  # pull_request_target ensures secrets are available even for fork PRs.
+  # Safe here because we never checkout PR code.
   pull_request_target:
     types: [opened, ready_for_review, closed]
 
 jobs:
-  notify:
+  notify-slack:
+    # Skip draft PRs; only run for opened, ready_for_review, closed+merged, or closed+unmerged events.
     if: |
       !github.event.pull_request.draft && (
         github.event.action == 'opened' ||
         github.event.action == 'ready_for_review' ||
         github.event.action == 'closed'
       )
-    uses: camunda/team-distribution/.github/workflows/notify-pr-activity.yml@main
-    with:
-      action:            ${{ github.event.action }}
-      pr_repo:           ${{ github.event.repository.name }}
-      pr_number:         ${{ github.event.pull_request.number }}
-      pr_title:          ${{ github.event.pull_request.title }}
-      pr_url:            ${{ github.event.pull_request.html_url }}
-      pr_author:         ${{ github.event.pull_request.user.login }}
-      pr_additions:      ${{ github.event.pull_request.additions }}
-      pr_deletions:      ${{ github.event.pull_request.deletions }}
-      pr_merged:         ${{ github.event.pull_request.merged }}
-      pr_merged_by:      ${{ (github.event.pull_request.merged_by && github.event.pull_request.merged_by.login) || '' }}
-      pr_created_at:     ${{ github.event.pull_request.created_at }}
-      pr_merged_at:      ${{ github.event.pull_request.merged_at || '' }}
-      pr_reviewers_json: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
-      pr_draft:          ${{ github.event.pull_request.draft }}
-      pr_labels_json:    ${{ toJSON(github.event.pull_request.labels) }}
-    secrets:
-      VAULT_ADDR:       ${{ secrets.VAULT_ADDR }}
-      VAULT_ROLE_ID:    ${{ secrets.VAULT_ROLE_ID }}
-      VAULT_SECRET_ID:  ${{ secrets.VAULT_SECRET_ID }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          sparse-checkout: scripts/notify-pr-activity
+          sparse-checkout-cone-mode: true
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: scripts/notify-pr-activity/go.mod
+
+      - name: Import Vault secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        id: vault-secrets
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_GH;
+          exportEnv: true
+
+      - name: Send Slack notification
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK:     ${{ env.SLACK_DISTRO_BOT_WEBHOOK_GH }}
+          GH_ACTION:         ${{ github.event.action }}
+          PR_REPO:           ${{ github.event.repository.name }}
+          PR_NUMBER:         ${{ github.event.pull_request.number }}
+          PR_TITLE:          ${{ github.event.pull_request.title }}
+          PR_URL:            ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR:         ${{ github.event.pull_request.user.login }}
+          PR_ADDITIONS:      ${{ github.event.pull_request.additions }}
+          PR_DELETIONS:      ${{ github.event.pull_request.deletions }}
+          PR_MERGED:         ${{ github.event.pull_request.merged }}
+          PR_MERGED_BY:      ${{ (github.event.pull_request.merged_by && github.event.pull_request.merged_by.login) || '' }}
+          PR_CREATED_AT:     ${{ github.event.pull_request.created_at }}
+          PR_MERGED_AT:      ${{ github.event.pull_request.merged_at || '' }}
+          PR_REVIEWERS_JSON: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+          PR_LABELS_JSON:    ${{ toJSON(github.event.pull_request.labels) }}
+        run: |
+          cd scripts/notify-pr-activity
+          go run .

--- a/scripts/notify-pr-activity/go.mod
+++ b/scripts/notify-pr-activity/go.mod
@@ -1,0 +1,3 @@
+module scripts/notify-pr-activity
+
+go 1.25.0

--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -1,0 +1,201 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const timeLayout = time.RFC3339
+
+type slackBlock struct {
+	Type string    `json:"type"`
+	Text slackText `json:"text"`
+}
+
+type slackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type slackPayload struct {
+	Blocks []slackBlock `json:"blocks"`
+}
+
+func mustEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		fmt.Fprintf(os.Stderr, "error: required env var %s is not set\n", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func shortRepo(name string) string {
+	return strings.TrimPrefix(name, "camunda-platform-")
+}
+
+func formatDuration(from, to time.Time) string {
+	diff := to.Sub(from)
+	days := int(diff.Hours()) / 24
+	hours := int(diff.Hours()) % 24
+	switch {
+	case days > 0 && hours > 0:
+		return fmt.Sprintf("%dd %dh", days, hours)
+	case days > 0:
+		return fmt.Sprintf("%dd", days)
+	case hours > 0:
+		return fmt.Sprintf("%dh", hours)
+	default:
+		return "< 1h"
+	}
+}
+
+// parseReviewers decodes a JSON array of GitHub user objects and returns "@login, ..." string.
+func parseReviewers(raw string) string {
+	var users []struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal([]byte(raw), &users); err != nil || len(users) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(users))
+	for _, u := range users {
+		names = append(names, "@"+u.Login)
+	}
+	return strings.Join(names, ", ")
+}
+
+func buildMessage() string {
+	action := mustEnv("GH_ACTION")
+	repo := shortRepo(mustEnv("PR_REPO"))
+	prURL := mustEnv("PR_URL")
+	prNum := "#" + mustEnv("PR_NUMBER")
+	prTitle := mustEnv("PR_TITLE")
+	authorLogin := mustEnv("PR_AUTHOR")
+	author := "@" + authorLogin
+
+	link := fmt.Sprintf("<%s|%s %s>", prURL, prNum, prTitle)
+
+	switch action {
+	case "opened", "ready_for_review":
+		size := fmt.Sprintf("+%s/-%s", mustEnv("PR_ADDITIONS"), mustEnv("PR_DELETIONS"))
+		reviewers := parseReviewers(os.Getenv("PR_REVIEWERS_JSON"))
+		reviewText := ""
+		if reviewers != "" {
+			reviewText = " · review: " + reviewers
+		}
+		return fmt.Sprintf(":arrow_heading_up: [%s] PR opened · by %s%s · %s — %s",
+			repo, author, reviewText, size, link)
+
+	case "closed":
+		merged := os.Getenv("PR_MERGED") == "true"
+		if merged {
+			createdAt, err1 := time.Parse(timeLayout, mustEnv("PR_CREATED_AT"))
+			mergedAt, err2 := time.Parse(timeLayout, mustEnv("PR_MERGED_AT"))
+			duration := "unknown"
+			if err1 == nil && err2 == nil {
+				duration = formatDuration(createdAt, mergedAt)
+			}
+			mergedByText := ""
+			if mergedBy := os.Getenv("PR_MERGED_BY"); mergedBy != "" && mergedBy != authorLogin {
+				mergedByText = " · merged by @" + mergedBy
+			}
+			return fmt.Sprintf(":tada: [%s] PR merged after %s · by %s%s — %s",
+				repo, duration, author, mergedByText, link)
+		}
+		return fmt.Sprintf(":x: [%s] PR closed without merge · by %s — %s",
+			repo, author, link)
+
+	default:
+		fmt.Fprintf(os.Stderr, "error: unhandled action %q\n", action)
+		os.Exit(1)
+		return ""
+	}
+}
+
+func sendSlack(webhook, message string) error {
+	payload := slackPayload{
+		Blocks: []slackBlock{
+			{Type: "section", Text: slackText{Type: "mrkdwn", Text: message}},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", webhook, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return nil
+}
+
+// hasLabel reports whether the JSON label array contains a label with the given name.
+// The array has the shape [{"name":"automerge",...},...]
+func hasLabel(labelsJSON, name string) bool {
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {
+		return false
+	}
+	for _, l := range labels {
+		if l.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func main() {
+	// Renovate PRs labelled "automerge" are handled automatically and generate no useful signal.
+	// Renovate PRs without "automerge" (e.g. major updates) still need human attention — notify those.
+	if os.Getenv("PR_AUTHOR") == "renovate[bot]" && hasLabel(os.Getenv("PR_LABELS_JSON"), "automerge") {
+		fmt.Println("ℹ️  Skipping Slack notification: automerge Renovate PR.")
+		return
+	}
+
+	webhook := mustEnv("SLACK_WEBHOOK")
+	message := buildMessage()
+
+	fmt.Printf("📣 Sending Slack notification: %s\n", message)
+
+	if err := sendSlack(webhook, message); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Slack notification failed (non-fatal): %v\n", err)
+	}
+}

--- a/scripts/notify-pr-activity/main_test.go
+++ b/scripts/notify-pr-activity/main_test.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func setCommonEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("PR_REPO", "camunda-distributions")
+	t.Setenv("PR_URL", "https://github.com/camunda/camunda-distributions/pull/123")
+	t.Setenv("PR_NUMBER", "123")
+	t.Setenv("PR_TITLE", "feat: add support for X")
+	t.Setenv("PR_AUTHOR", "octocat")
+}
+
+func TestBuildMessageOpened(t *testing.T) {
+	setCommonEnv(t)
+	t.Setenv("GH_ACTION", "opened")
+	t.Setenv("PR_ADDITIONS", "42")
+	t.Setenv("PR_DELETIONS", "7")
+	t.Setenv("PR_REVIEWERS_JSON", `[{"login":"reviewer1"},{"login":"reviewer2"}]`)
+
+	got := buildMessage()
+
+	for _, want := range []string{
+		":arrow_heading_up:",
+		"[camunda-distributions]", // no camunda-platform- prefix to strip
+		"PR opened · by @octocat",
+		"review: @reviewer1, @reviewer2",
+		"+42/-7",
+		"<https://github.com/camunda/camunda-distributions/pull/123|#123 feat: add support for X>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("opened message missing %q\n got: %s", want, got)
+		}
+	}
+}
+
+func TestBuildMessageOpenedNoReviewers(t *testing.T) {
+	setCommonEnv(t)
+	t.Setenv("GH_ACTION", "opened")
+	t.Setenv("PR_ADDITIONS", "1")
+	t.Setenv("PR_DELETIONS", "0")
+	t.Setenv("PR_REVIEWERS_JSON", "[]")
+
+	got := buildMessage()
+	if strings.Contains(got, "review:") {
+		t.Errorf("did not expect a review segment, got: %s", got)
+	}
+}
+
+func TestBuildMessageMergedByAuthor(t *testing.T) {
+	setCommonEnv(t)
+	t.Setenv("GH_ACTION", "closed")
+	t.Setenv("PR_MERGED", "true")
+	t.Setenv("PR_CREATED_AT", "2024-01-01T09:00:00Z")
+	t.Setenv("PR_MERGED_AT", "2024-01-02T13:00:00Z")
+	t.Setenv("PR_MERGED_BY", "octocat") // merger == author
+
+	got := buildMessage()
+	if !strings.Contains(got, ":tada:") || !strings.Contains(got, "PR merged after 1d 4h") || !strings.Contains(got, "by @octocat") {
+		t.Errorf("unexpected merged message: %s", got)
+	}
+	if strings.Contains(got, "merged by") {
+		t.Errorf("should omit 'merged by' when merger == author: %s", got)
+	}
+}
+
+func TestBuildMessageMergedByOther(t *testing.T) {
+	setCommonEnv(t)
+	t.Setenv("GH_ACTION", "closed")
+	t.Setenv("PR_MERGED", "true")
+	t.Setenv("PR_CREATED_AT", "2024-01-01T09:00:00Z")
+	t.Setenv("PR_MERGED_AT", "2024-01-01T10:00:00Z")
+	t.Setenv("PR_MERGED_BY", "mergerbot")
+
+	got := buildMessage()
+	if !strings.Contains(got, "· merged by @mergerbot") {
+		t.Errorf("expected 'merged by @mergerbot' segment, got: %s", got)
+	}
+	if !strings.Contains(got, "PR merged after 1h") {
+		t.Errorf("expected '1h' duration, got: %s", got)
+	}
+}
+
+func TestBuildMessageClosedUnmerged(t *testing.T) {
+	setCommonEnv(t)
+	t.Setenv("GH_ACTION", "closed")
+	t.Setenv("PR_MERGED", "false")
+
+	got := buildMessage()
+	if !strings.Contains(got, ":x:") || !strings.Contains(got, "closed without merge · by @octocat") {
+		t.Errorf("unexpected closed message: %s", got)
+	}
+}
+
+func TestShortRepo(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"camunda-platform-helm": "helm",
+		"camunda-distributions": "camunda-distributions",
+		"team-distribution":     "team-distribution",
+	}
+	for in, want := range cases {
+		if got := shortRepo(in); got != want {
+			t.Errorf("shortRepo(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #469

## What

Replace the reusable-workflow caller in `.github/workflows/notify-pr-activity.yml` with a self-contained workflow, and vendor the notifier Go script into `scripts/notify-pr-activity/` (`main.go` + `go.mod` + `main_test.go`, copied from the canonical version in `camunda/team-distribution`).

## Why

The previous workflow called `camunda/team-distribution/.github/workflows/notify-pr-activity.yml@main`. That repo is **internal** and this one is **public** — GitHub does not allow a public repo to use a reusable workflow from an internal/private repo, so the call failed validation before any job ran (every run failed). A GitHub App token can't bypass this; it's a repository-visibility rule evaluated at workflow parse time.

Vendoring the workflow + script (the same approach `camunda-platform-helm` already uses) makes it self-contained and unblocks custom PR notifications for this repo. Format matches the canonical notifier (`↗️`/`🎉`/`❌`, `· by @author`, size, `· merged by @X`). Automerge Renovate PRs are still filtered.

## Test

- `go test ./...` in `scripts/notify-pr-activity` — 6 pass; `go vet` + `gofmt` clean.
- `actionlint .github/workflows/notify-pr-activity.yml` clean.