### PR TITLE
fix(docker-compose): use internal connectors url in 8.8 console config

### DIFF
--- a/docker-compose/versions/camunda-8.8/.console/application.yaml
+++ b/docker-compose/versions/camunda-8.8/.console/application.yaml
@@ -78,6 +78,6 @@ camunda:
               id: "connectors"
               # renovate: datasource=docker depName=camunda/connectors-bundle
               version: "8.8.0"
-              url: "http://localhost:8086"
+              url: "http://connectors:8080"
               readiness: "http://connectors:8080/actuator/health/readiness"
               metrics: "http://connectors:8080/actuator/prometheus"


### PR DESCRIPTION
Closes #323

Console in the 8.8 full stack resolved the Connectors component URL as `http://localhost:8086`, which is unreachable from inside the Console container, so the Connector Management page always showed "An error occurred". This backports the fix from #362 (already applied to 8.9 and 8.10): the URL now points to the internal service address `http://connectors:8080`.

Verified locally on the 8.8 full stack: before the change, Console reported the Connectors component as unreachable (`ECONNREFUSED` from inside the container); after the change, Console reports Connectors as healthy.