### PR TITLE
docs(docker-compose): add opensearch secondary storage example

### DIFF
--- a/docker-compose/versions/camunda-8.10/README.md
+++ b/docker-compose/versions/camunda-8.10/README.md
@@ -30,6 +30,7 @@ Set `ORCHESTRATION_CONFIG_FILE` in `.env` (or export it before running `docker c
 - `application-postgresql.yaml`
 - `application-mssql.yaml`
 - `application-oracle.yaml`
+- `application-opensearch.yaml`
 
 Feel free to copy these files and adjust the JDBC URL/credentials for your environment. Example:
 
@@ -38,6 +39,8 @@ cd docker-compose/versions/camunda-8.10
 export ORCHESTRATION_CONFIG_FILE=application-mysql.yaml
 docker compose up -d
 ```
+
+The `application-opensearch.yaml` sample expects an OpenSearch instance reachable at `http://opensearch:9200`. OpenSearch is not bundled, so either point the URL at an existing instance or add one via a `docker-compose.override.yaml` on the same network — see [configure secondary storage with Docker Compose](https://docs.camunda.io/docs/self-managed/quickstart/developer-quickstart/docker-compose/secondary-storage/) for a ready-made example.
 
 ### JDBC drivers
 

--- a/docker-compose/versions/camunda-8.10/configuration/application-opensearch.yaml
+++ b/docker-compose/versions/camunda-8.10/configuration/application-opensearch.yaml
@@ -1,0 +1,31 @@
+management.endpoints.configprops.show-values: always
+camunda:
+  backup:
+    webapps:
+      enabled: false
+  system:
+    cpu-thread-count: "3"
+    io-thread-count: "3"
+  security:
+    authentication:
+      method: "basic"
+      unprotectedApi: true
+    authorizations:
+      enabled: false
+    initialization:
+      users:
+        - username: "demo"
+          password: "demo"
+          name: "Demo User"
+          email: "demo@demo.com"
+      defaultRoles.admin.users:
+        - "demo"
+  data:
+    secondary-storage:
+      type: opensearch
+      opensearch:
+        url: http://opensearch:9200
+        username: ""
+        password: ""
+  mcp:
+    enabled: true

--- a/docker-compose/versions/camunda-8.9/configuration/application-opensearch.yaml
+++ b/docker-compose/versions/camunda-8.9/configuration/application-opensearch.yaml
@@ -1,0 +1,31 @@
+management.endpoints.configprops.show-values: always
+camunda:
+  backup:
+    webapps:
+      enabled: false
+  system:
+    cpu-thread-count: "3"
+    io-thread-count: "3"
+  security:
+    authentication:
+      method: "basic"
+      unprotectedApi: true
+    authorizations:
+      enabled: false
+    initialization:
+      users:
+        - username: "demo"
+          password: "demo"
+          name: "Demo User"
+          email: "demo@demo.com"
+      defaultRoles.admin.users:
+        - "demo"
+  data:
+    secondary-storage:
+      type: opensearch
+      opensearch:
+        url: http://opensearch:9200
+        username: ""
+        password: ""
+  mcp:
+    enabled: true


### PR DESCRIPTION
Closes #68

Adds an `application-opensearch.yaml` sample to the `configuration/` directories of 8.9 and 8.10, following the pattern of the existing RDBMS samples, and lists it in the 8.10 README with a note on how to provide the OpenSearch instance (not bundled).

8.9 and 8.10 are the only versions with the `ORCHESTRATION_CONFIG_FILE` switching mechanism; 8.8 uses an inline config with bundled Elasticsearch and 8.7 predates the consolidated orchestration service, so a sample file cannot cover those.

Verified locally on both versions: started the lightweight stack with `ORCHESTRATION_CONFIG_FILE=application-opensearch.yaml` plus an OpenSearch 2.19.3 override container — orchestration and connectors became healthy, the `camunda-*` indices were created in OpenSearch, and the Orchestration API responded normally.