### PR TITLE
fix(docker-compose): attach mailpit to camunda-platform network

### DIFF
--- a/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
@@ -281,6 +281,7 @@ services:
       start_period: 10s
     networks:
       - web-modeler
+      - camunda-platform
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -419,6 +419,7 @@ services:
       interval: 30s
     networks:
       - web-modeler
+      - camunda-platform
 
   web-modeler-restapi:
     container_name: web-modeler-restapi

--- a/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
@@ -306,6 +306,7 @@ services:
       start_period: 10s
     networks:
       - web-modeler
+      - camunda-platform
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
@@ -316,6 +316,7 @@ services:
       start_period: 10s
     networks:
       - web-modeler
+      - camunda-platform
     extra_hosts:
       - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
Closes #195

Mailpit was only attached to the `web-modeler` network, so the orchestration and connectors containers could not resolve `mailpit:1025` — the Email Connector failed out of the box in every full setup. This adds the `camunda-platform` network to the mailpit service in 8.7 (`docker-compose.yaml`) and 8.8/8.9/8.10 (`docker-compose-full.yaml`); the `web-modeler` attachment stays, so Web Modeler mail is unaffected.

Verified locally on the 8.8 full stack: before the change, `getent hosts mailpit` failed from both orchestration and connectors; after recreating mailpit, both resolve it and an SMTP TCP connection to `mailpit:1025` succeeds.