### PR TITLE
feat(docker-compose): configure mailpit for optimize alerting

### DIFF
--- a/docker-compose/versions/camunda-8.10/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.10/.optimize/environment-config.yaml
@@ -23,3 +23,11 @@ ui:
 api:
   jwtSetUri: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
   audience: optimize-api
+
+# Send alert notifications via the bundled Mailpit SMTP server.
+# Replace hostname/port to use your own SMTP server.
+email:
+  enabled: true
+  address: optimize@camunda.example.com
+  hostname: mailpit
+  port: 1025

--- a/docker-compose/versions/camunda-8.7/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.7/.optimize/environment-config.yaml
@@ -9,3 +9,11 @@ es:
 api:
   jwtSetUri: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
   audience: optimize-api
+
+# Send alert notifications via the bundled Mailpit SMTP server.
+# Replace hostname/port to use your own SMTP server.
+email:
+  enabled: true
+  address: optimize@camunda.example.com
+  hostname: mailpit
+  port: 1025

--- a/docker-compose/versions/camunda-8.8/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.8/.optimize/environment-config.yaml
@@ -23,3 +23,11 @@ ui:
 api:
   jwtSetUri: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
   audience: optimize-api
+
+# Send alert notifications via the bundled Mailpit SMTP server.
+# Replace hostname/port to use your own SMTP server.
+email:
+  enabled: true
+  address: optimize@camunda.example.com
+  hostname: mailpit
+  port: 1025

--- a/docker-compose/versions/camunda-8.9/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.9/.optimize/environment-config.yaml
@@ -23,3 +23,11 @@ ui:
 api:
   jwtSetUri: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
   audience: optimize-api
+
+# Send alert notifications via the bundled Mailpit SMTP server.
+# Replace hostname/port to use your own SMTP server.
+email:
+  enabled: true
+  address: optimize@camunda.example.com
+  hostname: mailpit
+  port: 1025


### PR DESCRIPTION
Closes #81

Mailpit was already used for Web Modeler emails, but Optimize alerting had no email configuration, so alert notifications could not be sent out of the box. This adds the documented Optimize email settings (`email.enabled/address/hostname/port`, per the [Optimize email configuration](https://docs.camunda.io/docs/self-managed/components/optimize/configuration/system-configuration/#email)) to `.optimize/environment-config.yaml` for 8.7–8.10, pointing at the bundled mailpit service on port 1025.

Depends on #504, which attaches mailpit to the `camunda-platform` network — without it Optimize cannot resolve `mailpit`.

Verified locally on the 8.8 full stack (with #504 applied): Optimize restarts healthy with the new configuration and reaches `mailpit:1025` from inside the container. The full alert-to-inbox path was not exercised, as it requires creating a report and alert through the UI.