### PR TITLE
feat(docker-compose): add optimize public api security defaults

### DIFF
--- a/docker-compose/versions/camunda-8.10/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.identity/application.yaml
@@ -90,6 +90,9 @@ identity:
           root-url: "http://localhost:8083"
           redirect-uris:
             - "/api/authentication/callback"
+          permissions:
+            - audience: "optimize-api"
+              definition: write:*
       apis:
         - name: Optimize API
           audience: "optimize-api"

--- a/docker-compose/versions/camunda-8.10/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.10/.optimize/environment-config.yaml
@@ -17,3 +17,9 @@ security:
 ui:
   logoutHidden: true
 
+
+# Secure the Optimize public REST API against the local Keycloak.
+# Tokens must carry the optimize-api audience (Optimize API in Management Identity).
+api:
+  jwtSetUri: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
+  audience: optimize-api

--- a/docker-compose/versions/camunda-8.7/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.7/.optimize/environment-config.yaml
@@ -3,3 +3,9 @@ es:
     index:
       number_of_replicas: 0
 
+
+# Secure the Optimize public REST API against the local Keycloak.
+# Tokens must carry the optimize-api audience (e.g. the zeebe M2M client).
+api:
+  jwtSetUri: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
+  audience: optimize-api

--- a/docker-compose/versions/camunda-8.8/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.8/.identity/application.yaml
@@ -90,6 +90,9 @@ identity:
           root-url: "http://localhost:8083"
           redirect-uris:
             - "/api/authentication/callback"
+          permissions:
+            - audience: "optimize-api"
+              definition: write:*
       apis:
         - name: Optimize API
           audience: "optimize-api"

--- a/docker-compose/versions/camunda-8.8/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.8/.optimize/environment-config.yaml
@@ -17,3 +17,9 @@ security:
 ui:
   logoutHidden: true
 
+
+# Secure the Optimize public REST API against the local Keycloak.
+# Tokens must carry the optimize-api audience (Optimize API in Management Identity).
+api:
+  jwtSetUri: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
+  audience: optimize-api

--- a/docker-compose/versions/camunda-8.9/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.9/.identity/application.yaml
@@ -90,6 +90,9 @@ identity:
           root-url: "http://localhost:8083"
           redirect-uris:
             - "/api/authentication/callback"
+          permissions:
+            - audience: "optimize-api"
+              definition: write:*
       apis:
         - name: Optimize API
           audience: "optimize-api"

--- a/docker-compose/versions/camunda-8.9/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.9/.optimize/environment-config.yaml
@@ -17,3 +17,9 @@ security:
 ui:
   logoutHidden: true
 
+
+# Secure the Optimize public REST API against the local Keycloak.
+# Tokens must carry the optimize-api audience (Optimize API in Management Identity).
+api:
+  jwtSetUri: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
+  audience: optimize-api


### PR DESCRIPTION
Closes #151

The Optimize public REST API was unusable out of the box: no `jwtSetUri` or `accessToken` was configured, so Optimize rejected every request to it with 401. This makes it work by default in 8.7–8.10:

- `.optimize/environment-config.yaml` (all four versions): set `api.jwtSetUri` to the local Keycloak JWKS endpoint and `api.audience` to `optimize-api`, matching the Optimize API audience defined in Identity.
- `.identity/application.yaml` (8.8/8.9/8.10): grant the `optimize` application `write:*` permission on the `optimize-api` audience, so its client-credentials tokens actually carry that audience (following the pattern already used by the connectors application for `orchestration-api`). In 8.7 no Identity change is needed — the `zeebe` M2M client already has `optimize-api` permission via `KEYCLOAK_CLIENTS_0_PERMISSIONS_3`.

Verified locally on all four full stacks (8.7, 8.8, 8.9, and 8.10 with external Elasticsearch): before the change, a valid Keycloak client-credentials token got 401 from `/api/public/report`; after the change, the token carries the `optimize-api` audience and the same request returns 200, while requests without a token or with a token lacking the audience still get 401.