### PR TITLE
fix(docker-compose): use on-failure restart policy consistently

### DIFF
--- a/docker-compose/versions/camunda-8.10/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - path: .env
         required: true
     mem_limit: 1g
-    restart: always
+    restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/9600 && echo -e \"GET /actuator/health/status HTTP/1.1\r\nHost: localhost\r\n\r\n\" >&3 && head -n 1 <&3'"]
       interval: 1s
@@ -65,7 +65,7 @@ services:
       - path: .env
         required: true
     mem_limit: 512m
-    restart: unless-stopped
+    restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s

--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
     env_file:
       - path: .env
         required: true
-    restart: always
+    restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9600' || exit 1"]
       interval: 30s
@@ -377,7 +377,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-    restart: always
+    restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:9200/_cat/health | grep -q green"]
       interval: 30s

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
     env_file:
       - path: .env
         required: true
-    restart: always
+    restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/9600 && echo -e \"GET /actuator/health/status HTTP/1.1\r\nHost: localhost\r\n\r\n\" >&3 && head -n 1 <&3'"]
       interval: 1s
@@ -50,7 +50,7 @@ services:
       - connector-secrets.txt
       - path: .env
         required: true
-    restart: unless-stopped
+    restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s
@@ -80,7 +80,7 @@ services:
       - cluster.routing.allocation.disk.threshold_enabled=false
       # Disable noisy deprecation logs, see https://github.com/camunda/camunda/issues/26285
       - logger.org.elasticsearch.deprecation="OFF"
-    restart: unless-stopped
+    restart: on-failure
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:9200/_cat/health | grep -q green" ]
       interval: 1s

--- a/docker-compose/versions/camunda-8.9/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - path: .env
         required: true
     mem_limit: 1g
-    restart: always
+    restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/9600 && echo -e \"GET /actuator/health/status HTTP/1.1\r\nHost: localhost\r\n\r\n\" >&3 && head -n 1 <&3'"]
       interval: 1s
@@ -64,7 +64,7 @@ services:
       - path: .env
         required: true
     mem_limit: 512m
-    restart: unless-stopped
+    restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]
       interval: 30s


### PR DESCRIPTION
Closes #224

The compose files are meant for local development, but several services still used `restart: always` or `unless-stopped`, so stopped containers came back on their own after a Docker daemon or machine restart. The full-stack files already settled on `on-failure`; this aligns the remaining services with that policy — zeebe and elasticsearch in the 8.7 file, and orchestration/connectors/elasticsearch in the 8.8/8.9/8.10 lightweight files. `camunda-data-init` keeps `restart: "no"`. Crashed containers still recover, but nothing auto-starts on reboot anymore.

Verified locally on all four versions: recreated the affected services and confirmed via `docker inspect` that every service reports `RestartPolicy: on-failure` (and `no` for the data-init containers).