### PR TITLE
fix(docker-compose): forward .env to connectors and lightweight orchestration

### DIFF
--- a/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
@@ -80,7 +80,10 @@ services:
       CAMUNDA_CLIENT_AUTH_ISSUERURL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
       CAMUNDA_CLIENT_AUTH_CLIENTID: ${CONNECTORS_CLIENT_ID}
       CAMUNDA_CLIENT_AUTH_CLIENTSECRET: ${CONNECTORS_CLIENT_SECRET}
-    env_file: connector-secrets.txt
+    env_file:
+      - connector-secrets.txt
+      - path: .env
+        required: true
     restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]

--- a/docker-compose/versions/camunda-8.10/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose.yaml
@@ -27,6 +27,9 @@ services:
       - "8080:8080"
     environment:
       - JAVA_TOOL_OPTIONS="-XX:+PrintFlagsFinal"
+    env_file:
+      - path: .env
+        required: true
     mem_limit: 1g
     restart: always
     healthcheck:
@@ -57,7 +60,10 @@ services:
     environment:
       - management.endpoints.web.exposure.include=health,configprops
       - management.endpoint.health.probes.enabled=true
-    env_file: connector-secrets.txt
+    env_file:
+      - connector-secrets.txt
+      - path: .env
+        required: true
     mem_limit: 512m
     restart: unless-stopped
     healthcheck:

--- a/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
@@ -71,7 +71,10 @@ services:
       CAMUNDA_CLIENT_AUTH_TOKENURL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform/protocol/openid-connect/token
       CAMUNDA_CLIENT_AUTH_CLIENTID: ${CONNECTORS_CLIENT_ID}
       CAMUNDA_CLIENT_AUTH_CLIENTSECRET: ${CONNECTORS_CLIENT_SECRET}
-    env_file: connector-secrets.txt
+    env_file:
+      - connector-secrets.txt
+      - path: .env
+        required: true
     restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -16,6 +16,9 @@ services:
       - "26500:26500"
       - "9600:9600"
       - "8088:8080"
+    env_file:
+      - path: .env
+        required: true
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/9600 && echo -e \"GET /actuator/health/status HTTP/1.1\r\nHost: localhost\r\n\r\n\" >&3 && head -n 1 <&3'"]
@@ -43,7 +46,10 @@ services:
     environment:
       - management.endpoints.web.exposure.include=health,configprops
       - management.endpoint.health.probes.enabled=true
-    env_file: connector-secrets.txt
+    env_file:
+      - connector-secrets.txt
+      - path: .env
+        required: true
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]

--- a/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose-full.yaml
@@ -81,7 +81,10 @@ services:
       CAMUNDA_CLIENT_AUTH_ISSUERURL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
       CAMUNDA_CLIENT_AUTH_CLIENTID: ${CONNECTORS_CLIENT_ID}
       CAMUNDA_CLIENT_AUTH_CLIENTSECRET: ${CONNECTORS_CLIENT_SECRET}
-    env_file: connector-secrets.txt
+    env_file:
+      - connector-secrets.txt
+      - path: .env
+        required: true
     restart: on-failure
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/actuator/health/readiness"]

--- a/docker-compose/versions/camunda-8.9/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.9/docker-compose.yaml
@@ -26,6 +26,9 @@ services:
       - "8080:8080"
     environment:
       - JAVA_TOOL_OPTIONS="-XX:+PrintFlagsFinal"
+    env_file:
+      - path: .env
+        required: true
     mem_limit: 1g
     restart: always
     healthcheck:
@@ -56,7 +59,10 @@ services:
     environment:
       - management.endpoints.web.exposure.include=health,configprops
       - management.endpoint.health.probes.enabled=true
-    env_file: connector-secrets.txt
+    env_file:
+      - connector-secrets.txt
+      - path: .env
+        required: true
     mem_limit: 512m
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
Closes #488

The document store block in `.env` (and any other user-set variable there) never reached the containers that need it: the lightweight `orchestration` service had no `env_file` at all, and `connectors` only loaded `connector-secrets.txt` in both flavors. Users following the documented `.env` template got silently ignored settings.

This adds `.env` to the `env_file` list of `connectors` (both flavors) and `orchestration` (lightweight) in 8.8/8.9/8.10, mirroring the pattern already used by the full-flavor orchestration service. `connector-secrets.txt` stays first in the list.

Verified locally on all six combinations (8.8/8.9/8.10 × lightweight/full): with `DOCUMENT_DEFAULT_STORE_ID=in-memory` set in `.env`, the variable was absent from the containers before the change and present in both orchestration and connectors after it, with all services still becoming healthy.