### PR TITLE
docs(docker-compose): document multi-tenancy configuration

### DIFF
--- a/docker-compose/versions/camunda-8.10/README.md
+++ b/docker-compose/versions/camunda-8.10/README.md
@@ -45,6 +45,8 @@ The Camunda Docker image automatically loads any `.jar` dropped into `/driver-li
 
 ## Enabling multi-tenancy
 
+### Lightweight configuration
+
 The lightweight `docker-compose.yaml` runs with basic authentication and an unprotected API. To enable multi-tenancy, protect the API and switch on the tenancy checks by creating a `docker-compose.override.yaml` next to the compose file:
 
 ```yaml
@@ -72,3 +74,24 @@ curl -u demo:demo -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo
 ```
 
 API clients must authenticate with basic auth once the API is protected (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
+### Full configuration
+
+The full `docker-compose-full.yaml` already protects the API through Keycloak, so only the tenancy checks need to be switched on. Add the following to `.env`:
+
+```bash
+CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+```
+
+Then start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the Orchestration Cluster API with an OAuth token (or the Identity UI at `http://localhost:8080/identity`):
+
+```bash
+TOKEN=$(curl -s -X POST 'http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token' \
+  -d 'grant_type=client_credentials' -d 'client_id=orchestration' -d 'client_secret=secret' | jq -r .access_token)
+# create a tenant
+curl -X POST http://localhost:8080/v2/tenants -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# assign the demo user to it
+curl -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo -H "Authorization: Bearer $TOKEN"
+```

--- a/docker-compose/versions/camunda-8.10/README.md
+++ b/docker-compose/versions/camunda-8.10/README.md
@@ -42,3 +42,33 @@ docker compose up -d
 ### JDBC drivers
 
 The Camunda Docker image automatically loads any `.jar` dropped into `/driver-lib`. A writable `driver-lib/` folder is included next to the compose file so you can copy the vendor JDBC driver there before starting (e.g., `driver-lib/mysql-connector-j-9.0.0.jar`). This is required for MySQL/MariaDB, SQL Server, and Oracle. PostgreSQL and H2 drivers are already bundled.
+
+## Enabling multi-tenancy
+
+The lightweight `docker-compose.yaml` runs with basic authentication and an unprotected API. To enable multi-tenancy, protect the API and switch on the tenancy checks by creating a `docker-compose.override.yaml` next to the compose file:
+
+```yaml
+services:
+  orchestration:
+    environment:
+      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
+      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+  connectors:
+    environment:
+      - CAMUNDA_CLIENT_AUTH_METHOD=basic
+      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+```
+
+Then start the stack with `docker compose up -d` and manage tenants through the Orchestration Cluster API (or the Identity UI at `http://localhost:8080/identity`):
+
+```bash
+# create a tenant
+curl -u demo:demo -X POST http://localhost:8080/v2/tenants \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# assign the demo user to it
+curl -u demo:demo -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo
+```
+
+API clients must authenticate with basic auth once the API is protected (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).

--- a/docker-compose/versions/camunda-8.10/README.md
+++ b/docker-compose/versions/camunda-8.10/README.md
@@ -63,7 +63,7 @@ services:
       - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
 ```
 
-Then start the stack with `docker compose up -d` and manage tenants through the Orchestration Cluster API (or the Identity UI at `http://localhost:8080/identity`):
+Then start the stack with `docker compose up -d` and manage tenants through the Orchestration Cluster API (or the Orchestration Cluster Admin UI at `http://localhost:8080/admin`):
 
 ```bash
 # create a tenant
@@ -84,7 +84,7 @@ CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
 CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
 ```
 
-Then start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the Orchestration Cluster API with an OAuth token (or the Identity UI at `http://localhost:8080/identity`):
+Then start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the Orchestration Cluster API with an OAuth token (or the Orchestration Cluster Admin UI at `http://localhost:8080/admin`):
 
 ```bash
 TOKEN=$(curl -s -X POST 'http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token' \

--- a/docker-compose/versions/camunda-8.7/README.md
+++ b/docker-compose/versions/camunda-8.7/README.md
@@ -3,3 +3,22 @@
 ## Usage
 
 For end user usage, please check the offical documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/self-managed/setup/deploy/local/docker-compose/).
+
+## Enabling multi-tenancy
+
+Multi-tenancy requires Zeebe to authenticate through Identity. Set the following in `.env`:
+
+```bash
+ZEEBE_AUTHENTICATION_MODE=identity
+MULTI_TENANCY_ENABLED=true
+```
+
+Then start the stack with `docker compose up -d` and manage tenants in the Identity UI at `http://localhost:8084` (log in as `demo`/`demo`), or through the Identity API:
+
+```bash
+# create a tenant (token from the camunda-identity client, e.g. via password grant for the demo user)
+curl -X POST http://localhost:8084/api/tenants -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+```
+
+API clients must use OAuth client credentials (e.g. the `zeebe` client from `.env`) once authentication is enabled.

--- a/docker-compose/versions/camunda-8.8/README.md
+++ b/docker-compose/versions/camunda-8.8/README.md
@@ -3,3 +3,33 @@
 ## Usage
 
 For end user usage, please check the offical documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/docker-compose/).
+
+## Enabling multi-tenancy
+
+The lightweight `docker-compose.yaml` runs with basic authentication and an unprotected API. To enable multi-tenancy, protect the API and switch on the tenancy checks by creating a `docker-compose.override.yaml` next to the compose file:
+
+```yaml
+services:
+  orchestration:
+    environment:
+      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
+      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+  connectors:
+    environment:
+      - CAMUNDA_CLIENT_AUTH_METHOD=basic
+      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+```
+
+Then start the stack with `docker compose up -d` and manage tenants through the Orchestration Cluster API (or the Identity UI at `http://localhost:8088/identity`):
+
+```bash
+# create a tenant
+curl -u demo:demo -X POST http://localhost:8088/v2/tenants \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# assign the demo user to it
+curl -u demo:demo -X PUT http://localhost:8088/v2/tenants/tenant-a/users/demo
+```
+
+API clients must authenticate with basic auth once the API is protected (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).

--- a/docker-compose/versions/camunda-8.8/README.md
+++ b/docker-compose/versions/camunda-8.8/README.md
@@ -6,6 +6,8 @@ For end user usage, please check the offical documentation of [Camunda 8 Self-Ma
 
 ## Enabling multi-tenancy
 
+### Lightweight configuration
+
 The lightweight `docker-compose.yaml` runs with basic authentication and an unprotected API. To enable multi-tenancy, protect the API and switch on the tenancy checks by creating a `docker-compose.override.yaml` next to the compose file:
 
 ```yaml
@@ -33,3 +35,24 @@ curl -u demo:demo -X PUT http://localhost:8088/v2/tenants/tenant-a/users/demo
 ```
 
 API clients must authenticate with basic auth once the API is protected (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
+### Full configuration
+
+The full `docker-compose-full.yaml` already protects the API through Keycloak, so only the tenancy checks need to be switched on. Add the following to `.env`:
+
+```bash
+CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+```
+
+Then start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the Orchestration Cluster API with an OAuth token (or the Identity UI at `http://localhost:8088/identity`):
+
+```bash
+TOKEN=$(curl -s -X POST 'http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token' \
+  -d 'grant_type=client_credentials' -d 'client_id=orchestration' -d 'client_secret=secret' | jq -r .access_token)
+# create a tenant
+curl -X POST http://localhost:8088/v2/tenants -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# assign the demo user to it
+curl -X PUT http://localhost:8088/v2/tenants/tenant-a/users/demo -H "Authorization: Bearer $TOKEN"
+```

--- a/docker-compose/versions/camunda-8.9/README.md
+++ b/docker-compose/versions/camunda-8.9/README.md
@@ -3,3 +3,33 @@
 ## Usage
 
 For end user usage, please check the offical documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/docker-compose/).
+
+## Enabling multi-tenancy
+
+The lightweight `docker-compose.yaml` runs with basic authentication and an unprotected API. To enable multi-tenancy, protect the API and switch on the tenancy checks by creating a `docker-compose.override.yaml` next to the compose file:
+
+```yaml
+services:
+  orchestration:
+    environment:
+      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
+      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+      - CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+  connectors:
+    environment:
+      - CAMUNDA_CLIENT_AUTH_METHOD=basic
+      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+```
+
+Then start the stack with `docker compose up -d` and manage tenants through the Orchestration Cluster API (or the Identity UI at `http://localhost:8080/identity`):
+
+```bash
+# create a tenant
+curl -u demo:demo -X POST http://localhost:8080/v2/tenants \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# assign the demo user to it
+curl -u demo:demo -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo
+```
+
+API clients must authenticate with basic auth once the API is protected (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).

--- a/docker-compose/versions/camunda-8.9/README.md
+++ b/docker-compose/versions/camunda-8.9/README.md
@@ -24,7 +24,7 @@ services:
       - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
 ```
 
-Then start the stack with `docker compose up -d` and manage tenants through the Orchestration Cluster API (or the Identity UI at `http://localhost:8080/identity`):
+Then start the stack with `docker compose up -d` and manage tenants through the Orchestration Cluster API (or the Orchestration Cluster Admin UI at `http://localhost:8080/admin`):
 
 ```bash
 # create a tenant
@@ -45,7 +45,7 @@ CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
 CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
 ```
 
-Then start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the Orchestration Cluster API with an OAuth token (or the Identity UI at `http://localhost:8080/identity`):
+Then start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the Orchestration Cluster API with an OAuth token (or the Orchestration Cluster Admin UI at `http://localhost:8080/admin`):
 
 ```bash
 TOKEN=$(curl -s -X POST 'http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token' \

--- a/docker-compose/versions/camunda-8.9/README.md
+++ b/docker-compose/versions/camunda-8.9/README.md
@@ -6,6 +6,8 @@ For end user usage, please check the offical documentation of [Camunda 8 Self-Ma
 
 ## Enabling multi-tenancy
 
+### Lightweight configuration
+
 The lightweight `docker-compose.yaml` runs with basic authentication and an unprotected API. To enable multi-tenancy, protect the API and switch on the tenancy checks by creating a `docker-compose.override.yaml` next to the compose file:
 
 ```yaml
@@ -33,3 +35,24 @@ curl -u demo:demo -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo
 ```
 
 API clients must authenticate with basic auth once the API is protected (`camunda.client.auth.method=basic` plus username and password in the Camunda client SDKs).
+
+### Full configuration
+
+The full `docker-compose-full.yaml` already protects the API through Keycloak, so only the tenancy checks need to be switched on. Add the following to `.env`:
+
+```bash
+CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=true
+CAMUNDA_SECURITY_MULTITENANCY_APIENABLED=true
+```
+
+Then start the stack with `docker compose -f docker-compose-full.yaml up -d` and manage tenants through the Orchestration Cluster API with an OAuth token (or the Identity UI at `http://localhost:8080/identity`):
+
+```bash
+TOKEN=$(curl -s -X POST 'http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token' \
+  -d 'grant_type=client_credentials' -d 'client_id=orchestration' -d 'client_secret=secret' | jq -r .access_token)
+# create a tenant
+curl -X POST http://localhost:8080/v2/tenants -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"tenantId": "tenant-a", "name": "Tenant A"}'
+# assign the demo user to it
+curl -X PUT http://localhost:8080/v2/tenants/tenant-a/users/demo -H "Authorization: Bearer $TOKEN"
+```


### PR DESCRIPTION
Closes #186

Multi-tenancy was configurable but undocumented since #185 removed the old `MULTI_TENANCY_ENABLED` passthrough for 8.8+, and users in the issue spent several alphas guessing at the right combination. This adds an "Enabling multi-tenancy" section to each version README:

- **8.8/8.9/8.10 lightweight**: a `docker-compose.override.yaml` that protects the API (`CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false`) and enables `CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED` / `APIENABLED`, plus basic-auth credentials for connectors and curl examples for creating a tenant and assigning a user.
- **8.8/8.9/8.10 full**: the API is already protected through Keycloak, so only the two tenancy-check variables go into `.env`; tenant management via the Orchestration Cluster API with an OAuth token.
- **8.7**: the existing `.env` toggles (`ZEEBE_AUTHENTICATION_MODE=identity`, `MULTI_TENANCY_ENABLED=true`) and tenant management via the Identity UI/API.

A companion PR adds the same guidance to the official Docker Compose pages in camunda-docs: camunda/camunda-docs#9404.

Verified locally on every documented combination: lightweight 8.8/8.9/8.10 (unauth 401, tenant create 201, user assign 204, tenant visible in search, connectors healthy with basic auth), full 8.8/8.9/8.10 with the two `.env` variables (unauth 401, create 201 and assign 204 with an OAuth client-credentials token), and 8.7 (identity healthy with multi-tenancy enabled on current patch versions, tenant created and listed via the Identity API).