### PR TITLE
ci(github-actions): install playwright browsers and run full e2e matrix on shared ci changes

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -17,3 +17,8 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: npm ci
+
+    - name: Install Playwright browsers
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: npx playwright install --with-deps chromium

--- a/.github/workflows/docker-compose-test-e2e-full-setup.yaml
+++ b/.github/workflows/docker-compose-test-e2e-full-setup.yaml
@@ -47,36 +47,6 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          # Camunda 8.4
-          - name: Camunda 8.4 ⭐
-            camunda-version: "8.4"
-            main-compose-args: "-f docker-compose.yaml"
-            e2e-test-enabled: false
-          - name: Camunda 8.4 - Identity Disabled
-            camunda-version: "8.4"
-            main-compose-args: "-f docker-compose-core.yaml"
-            e2e-test-enabled: false
-          # Camunda 8.5
-          - name: Camunda 8.5 ⭐
-            camunda-version: "8.5"
-            main-compose-args: "-f docker-compose.yaml"
-            e2e-test-enabled: false
-          - name: Camunda 8.5 - Identity Disabled
-            camunda-version: "8.5"
-            main-compose-args: "-f docker-compose-core.yaml"
-            e2e-test-enabled: false
-          # Camunda 8.6
-          - name: Camunda 8.6 ⭐
-            camunda-version: "8.6"
-            e2e-test-enabled: true
-          - name: Camunda 8.6 - Identity Disabled
-            camunda-version: "8.6"
-            main-compose-args: "-f docker-compose-core.yaml"
-            e2e-test-enabled: false
-          - name: Camunda 8.6 - Web Modeler Standalone
-            camunda-version: "8.6"
-            main-compose-args: "-f docker-compose-web-modeler.yaml"
-            e2e-test-enabled: false
           # Camunda 8.7
           - name: Camunda 8.7 ⭐
             camunda-version: "8.7"

--- a/.github/workflows/docker-compose-test-e2e-full-setup.yaml
+++ b/.github/workflows/docker-compose-test-e2e-full-setup.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - .github/workflows/docker-compose-test-e2e-template.yaml
       - .github/workflows/docker-compose-test-e2e-full-setup.yaml
+      - .github/actions/**
       - docker-compose/versions/**
 
 concurrency:
@@ -21,11 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Detect shared CI changes
+        id: ci-changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            ci:
+              - .github/workflows/docker-compose-test-e2e-template.yaml
+              - .github/workflows/docker-compose-test-e2e-full-setup.yaml
+              - .github/actions/**
       - name: Generate versions
         id: generate-versions-matrix
         uses: ./.github/actions/generate-versions-matrix
         with:
           versions-path: "docker-compose/versions/camunda-8.*"
+          reset-versions: ${{ steps.ci-changes.outputs.ci }}
     outputs:
       unchanged-versions: ${{ steps.generate-versions-matrix.outputs.unchanged }}
 
@@ -123,7 +134,9 @@ jobs:
     secrets: inherit
     with:
       camunda-version: ${{ matrix.versions.camunda-version }}
+      deps-compose-args: ${{ matrix.versions.deps-compose-args || '' }}
       main-compose-args: ${{ matrix.versions.main-compose-args }}
       e2e-test-enabled: ${{ matrix.versions.e2e-test-enabled }}
       e2e-test-directory: ${{ matrix.versions.e2e-test-directory || 'docker-compose/test/e2e' }}
       e2e-test-args: ${{ matrix.versions.e2e-test-args || '' }}
+      timeout-minutes: ${{ matrix.versions.timeout-minutes || 30 }}

--- a/.github/workflows/docker-compose-test-e2e-template.yaml
+++ b/.github/workflows/docker-compose-test-e2e-template.yaml
@@ -27,6 +27,11 @@ on:
         description: Arguments supplied to Playwright
         required: false
         type: string
+      timeout-minutes:
+        description: Job timeout in minutes
+        required: false
+        type: number
+        default: 30
 
 env:
   COMPOSE_WORKING_DIRECTORY: docker-compose/versions/camunda-${{ inputs.camunda-version }}
@@ -36,7 +41,7 @@ jobs:
     # if: contains(inputs.changed-versions, inputs.camunda-version)
     name: Run
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       #
       # Init.

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -47,6 +47,7 @@ jobs:
               - docker-compose/versions/**
               - .github/workflows/docker-compose-test-e2e-template.yaml
               - .github/workflows/docker-compose-test-e2e-full-setup.yaml
+              - .github/actions/**
 
       - name: Post gate status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log*
 test-results/
 playwright-report/
 playwright/.cache/
+docker-compose/versions/*/tests-lightweight/resources
 *.png
 *.jpg
 *.jpeg


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #514.

### What's in this PR?

- `install-playwright` action installs Playwright's bundled Chromium (`npx playwright install --with-deps chromium`) after `npm ci` — until now suites only worked when configured with `channel: 'chrome'`.
- The reusable e2e template's job timeout becomes a `timeout-minutes` input (default 30) so matrix entries with long-running suites can raise it.
- The e2e workflow triggers on `.github/actions/**` and resets the changed-versions filter when shared CI files change, so a CI-only PR runs the full matrix instead of skipping every entry while the merge gate mirrors green.
- The merge gate's e2e path filter includes `.github/actions/**`.
- The matrix drops Camunda 8.4/8.5/8.6: per `charts/chart-versions.yaml` in camunda-platform-helm these are `supportExtended`, and the helm chart's own CI only tests `alpha` + `supportStandard` versions — release workflows are unaffected, matching the helm repo's model.
- `.gitignore` covers the `tests-lightweight/resources` symlink created by the per-version e2e packages.