### PR TITLE
docs(docker-compose): document lightweight and full-stack e2e coverage

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -35,19 +35,22 @@ Triggers on push to `main` or PR touching `docker-compose/versions/**`.
 
 - **init job**: Runs `generate-versions-matrix` to build an exclude list of unchanged versions (skip-if-unchanged optimization).
 - **exec job**: Fans out across all version matrix entries; passes compose args, e2e flag, and test directory to the reusable template.
-- Each matrix entry specifies: `camunda-version`, `main-compose-args`, `e2e-test-enabled`, optional `e2e-test-directory`.
-- E2E tests default to `docker-compose/test/e2e`; versions 8.8+ use their own `docker-compose/versions/camunda-X.Y/tests/`.
+- Each matrix entry specifies: `camunda-version`, `main-compose-args`, `e2e-test-enabled`, optional `e2e-test-directory`, `e2e-test-args`, `deps-compose-args`, and `timeout-minutes`.
+- E2E tests default to `docker-compose/test/e2e`; versions 8.8+ use their own `docker-compose/versions/camunda-X.Y/tests/` (full-stack) and `tests-lightweight/` (lightweight, `@camunda/e2e-test-suite` c8Run suite).
 - Matrix entries marked ⭐ are the primary configs per version (full-stack with e2e enabled).
+- The 8.10 full-stack entry uses `deps-compose-args` to start `tests/docker-compose.elasticsearch-ci.yaml` before the main compose, since 8.10 no longer bundles Elasticsearch.
 
 ### E2E Test Template (`docker-compose-test-e2e-template.yaml`)
 
 Reusable workflow called by the full-setup. Steps:
 1. Checkout repo.
-2. `install-playwright` composite action (Node 24, npm cache, Playwright Chromium).
-3. Start Docker Compose services.
+2. `install-playwright` composite action (Node 24, `npm ci`, `npx playwright install --with-deps chromium`).
+3. Start Docker Compose dependencies (`deps-compose-args`, if set), then the main services.
 4. Wait for health checks.
 5. Run `npx playwright test` with configured args.
 6. Upload HTML report as artifact (30-day retention).
+
+Job timeout defaults to 30 minutes; matrix entries can raise it via `timeout-minutes` (the c8Run suite's connectors webhook spec waits 5 minutes synchronously, so lightweight entries use 45).
 
 Playwright config: Chromium only in CI (`retries: 2`, `workers: 1`).
 

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -31,11 +31,11 @@ docker-compose/
 
 ### E2E Tests (`docker-compose-test-e2e-full-setup.yaml`)
 
-Triggers on push to `main` or PR touching `docker-compose/versions/**`.
+Runs on pushes to `main` that touch `docker-compose/versions/**`, and on pull requests that touch version files, either E2E workflow, or anything under `.github/actions/**`.
 
 - **init job**: Runs `generate-versions-matrix` to build an exclude list of unchanged versions (skip-if-unchanged optimization).
 - **exec job**: Fans out across all version matrix entries; passes compose args, e2e flag, and test directory to the reusable template.
-- Each matrix entry specifies: `camunda-version`, `main-compose-args`, `e2e-test-enabled`, optional `e2e-test-directory`, `e2e-test-args`, `deps-compose-args`, and `timeout-minutes`.
+- Each matrix entry sets `name`, `camunda-version`, `main-compose-args`, and `e2e-test-enabled`; optional fields are `e2e-test-directory`, `e2e-test-args`, `deps-compose-args`, and `timeout-minutes`.
 - E2E tests default to `docker-compose/test/e2e`; versions 8.8+ use their own `docker-compose/versions/camunda-X.Y/tests/` (full-stack) and `tests-lightweight/` (lightweight, `@camunda/e2e-test-suite` c8Run suite).
 - Matrix entries marked ⭐ are the primary configs per version (full-stack with e2e enabled).
 - The 8.10 full-stack entry uses `deps-compose-args` to start `tests/docker-compose.elasticsearch-ci.yaml` before the main compose, since 8.10 no longer bundles Elasticsearch.
@@ -50,9 +50,9 @@ Reusable workflow called by the full-setup. Steps:
 5. Run `npx playwright test` with configured args.
 6. Upload HTML report as artifact (30-day retention).
 
-Job timeout defaults to 30 minutes; matrix entries can raise it via `timeout-minutes` (the c8Run suite's connectors webhook spec waits 5 minutes synchronously, so lightweight entries use 45).
+Job timeout defaults to 30 minutes. The 8.8–8.10 full-stack and lightweight entries use 45 minutes to leave room for container startup, long connector and webhook flows, and CI retries.
 
-Playwright config: Chromium only in CI (`retries: 2`, `workers: 1`).
+Playwright uses two retries and one worker in CI. Shared and full-stack suites launch the Chrome channel; lightweight suites launch Playwright Chromium.
 
 ### Release (`docker-compose-release.yaml`)
 

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -11,7 +11,7 @@ docker-compose/
   versions/
     camunda-8.4/ … camunda-8.10/   # Per-version compose configs
   test/
-    e2e/                            # Shared Playwright tests (used by 8.4–8.7)
+    e2e/                            # Shared Playwright tests (used by 8.7)
 
 .github/
   actions/

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -10,7 +10,7 @@ Playwright tests validate that each Docker Compose setup starts correctly and th
 
 | Path | Used by versions | Purpose |
 |------|-----------------|---------|
-| `docker-compose/test/e2e/` | 8.4–8.7 | Shared tests: login flows for Operate, Tasklist |
+| `docker-compose/test/e2e/` | 8.7 | Shared tests: login flows for Operate, Tasklist |
 | `docker-compose/versions/camunda-8.8/tests/` | 8.8 full-stack | Login flows for all full-stack apps plus `cross-component-happy-path.spec.ts` (deploy a process, complete a user task in Tasklist, verify completion in Operate), `connectors-flow.spec.ts` (outbound REST connector against Keycloak's discovery endpoint), `webhook-flow.spec.ts` (inbound webhook creates an instance), and `api-smoke.spec.ts` (REST v2 searches, connectors runtime health, negative auth checks) |
 | `docker-compose/versions/camunda-8.9/tests/` | 8.9 full-stack | Same as 8.8 |
 | `docker-compose/versions/camunda-8.10/tests/` | 8.10 full-stack, Web Modeler standalone | Same as 8.8 minus Console (no console service in 8.10); also holds `docker-compose.elasticsearch-ci.yaml` (throwaway ES for CI) |

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -4,7 +4,7 @@ title: E2E Testing
 
 # E2E Testing
 
-Playwright tests validate that each Docker Compose setup starts correctly and that the web UIs are accessible. Tests run in CI for every version on push to `main` or on PRs that touch `docker-compose/versions/**`.
+Playwright tests validate that each Docker Compose setup starts correctly and that its APIs and web UIs work. CI runs the affected supported-version entries for pushes to `main` and relevant pull requests; changes to shared E2E workflows or actions run the full matrix.
 
 ## Test Layout
 
@@ -21,7 +21,7 @@ Version-specific test directories are used when `e2e-test-directory` is specifie
 ### Lightweight suite notes
 
 - The specs live inside the npm package (`node_modules/@camunda/e2e-test-suite/dist/tests/c8Run-8.X`); this repo only pins the package version and provides `playwright.config.ts` plus a checked-in `.env` with the stack's URLs.
-- The package resolves BPMN fixtures relative to the working directory, so `postinstall` symlinks `resources -> node_modules/@camunda/e2e-test-suite/resources` (the symlink is gitignored).
+- The package resolves BPMN fixtures relative to the working directory, so `postinstall` links `resources` to `node_modules/@camunda/e2e-test-suite/resources`, falling back to a copy where links are unavailable. The generated path is gitignored.
 - `zeebe-node` must stay an explicit devDependency: the package requires it at runtime but does not declare it as a dependency.
 - The `.env` sets `PLAYWRIGHT_BASE_URL` per version (8.8 publishes the orchestration REST API on host port `8088`, 8.9/8.10 on `8080`) and `DATABASE` (`ES` for 8.8, `RDBMS` for 8.9/8.10) which some specs use to self-skip.
 
@@ -38,7 +38,7 @@ docker compose ps   # all services should show "healthy"
 # 3. Run the version-specific tests
 cd tests
 npm ci
-npx playwright install --with-deps chromium
+npx playwright install --with-deps chrome
 npx playwright test
 
 # Or run the shared tests
@@ -66,6 +66,11 @@ To test the 8.10 full stack locally, bring up the throwaway Elasticsearch first:
 cd docker-compose/versions/camunda-8.10
 docker compose -f tests/docker-compose.elasticsearch-ci.yaml up -d
 docker compose -f docker-compose-full.yaml up -d --wait --wait-timeout 300
+
+cd tests
+npm ci
+npx playwright install --with-deps chrome
+npx playwright test
 ```
 
 To run the focused Camunda 8.10 Keycloak and Web Modeler flow used in CI:
@@ -83,18 +88,19 @@ npx playwright test web_modeler_login.spec.ts
 
 ## CI Configuration
 
-- **Browser**: Chromium only (Firefox and Safari are commented out to reduce CI time).
-- **Retries**: 2 retries in CI, 0 locally.
+- **Browser**: Shared and full-stack suites use Google Chrome; lightweight suites use Playwright Chromium. Firefox and WebKit are not configured.
+- **Retries**: 2 retries in CI. Locally, the shared 8.7 suite uses 0 retries and the version-specific suites use 1.
 - **Workers**: 1 (no parallel execution) in CI.
 - **Reports**: HTML artifacts uploaded with 30-day retention.
 - **Test gate**: Only versions with `e2e-test-enabled: true` in the matrix actually run Playwright. Others only validate that compose starts and becomes healthy.
 - **Lightweight jobs (8.8–8.10)**: run the `c8Run-8.X` suite from `@camunda/e2e-test-suite` against `docker-compose.yaml` with a 45-minute timeout (the connectors webhook spec waits 5 minutes synchronously).
-- **8.10 full-stack job**: brings up `tests/docker-compose.elasticsearch-ci.yaml` via the template's `deps-compose-args` before `docker-compose-full.yaml`, then runs every spec in `tests/` (`web_modeler_login.spec.ts` works there too — the hub service publishes host port `8070` in the full stack, same as the standalone setup).
+- **Full-stack jobs (8.8–8.10)**: run the per-version suites with a 45-minute timeout for long flows and retries. The 8.10 job first brings up `tests/docker-compose.elasticsearch-ci.yaml` via `deps-compose-args`, then runs every spec in `tests/` against `docker-compose-full.yaml` (`web_modeler_login.spec.ts` works there too — the hub service publishes host port `8070` in the full stack, same as the standalone setup).
 - **Shared CI file changes** (the two e2e workflows or anything under `.github/actions/`) reset the changed-versions filter so the whole matrix runs, and the merge gate treats them as e2e-relevant — a CI-only PR cannot go green without executing tests.
 - **8.10 Web Modeler standalone job**: runs `web_modeler_login.spec.ts`, covering Keycloak startup, Identity realm initialization, and the browser OIDC callback without requiring external Elasticsearch.
 
 ## Adding Tests for a New Version
 
-1. Copy `tests/` from the nearest existing version into the new version directory.
-2. Add a matrix entry in `.github/workflows/docker-compose-test-e2e-full-setup.yaml` with `e2e-test-enabled: true` and `e2e-test-directory: docker-compose/versions/camunda-X.Y/tests`.
-3. Run locally against the new version to validate before pushing.
+1. Copy `tests/` from the nearest existing version and update any version-specific URLs, services, and test resources.
+2. If the version has a lightweight stack, copy `tests-lightweight/` and update the `@camunda/e2e-test-suite` version, the `c8Run-X.Y` `testDir`, and the URLs and database type in `.env`.
+3. Add one matrix entry per tested Compose variant in `.github/workflows/docker-compose-test-e2e-full-setup.yaml`. Set `e2e-test-enabled`, `e2e-test-directory`, and any required `deps-compose-args`, `e2e-test-args`, or `timeout-minutes`.
+4. Run `npm ci` in each test directory, then run every suite locally against its matching Compose stack before pushing.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -10,12 +10,20 @@ Playwright tests validate that each Docker Compose setup starts correctly and th
 
 | Path | Used by versions | Purpose |
 |------|-----------------|---------|
-| `docker-compose/test/e2e/` | 8.4–8.7 (and 8.8–8.9 lightweight) | Shared tests: login flows for Operate, Tasklist |
-| `docker-compose/versions/camunda-8.8/tests/` | 8.8 full-stack | Full-stack tests including Optimize, Web Modeler, Console |
+| `docker-compose/test/e2e/` | 8.4–8.7 | Shared tests: login flows for Operate, Tasklist |
+| `docker-compose/versions/camunda-8.8/tests/` | 8.8 full-stack | Login flows for all full-stack apps plus `cross-component-happy-path.spec.ts` (deploy a process, complete a user task in Tasklist, verify completion in Operate), `connectors-flow.spec.ts` (outbound REST connector against Keycloak's discovery endpoint), `webhook-flow.spec.ts` (inbound webhook creates an instance), and `api-smoke.spec.ts` (REST v2 searches, connectors runtime health, negative auth checks) |
 | `docker-compose/versions/camunda-8.9/tests/` | 8.9 full-stack | Same as 8.8 |
-| `docker-compose/versions/camunda-8.10/tests/` | 8.10 | Version-specific login tests; CI runs the Web Modeler test against the standalone setup |
+| `docker-compose/versions/camunda-8.10/tests/` | 8.10 full-stack, Web Modeler standalone | Same as 8.8 minus Console (no console service in 8.10); also holds `docker-compose.elasticsearch-ci.yaml` (throwaway ES for CI) |
+| `docker-compose/versions/camunda-8.X/tests-lightweight/` | 8.8–8.10 lightweight | The `c8Run-8.X` project from the [`@camunda/e2e-test-suite`](https://www.npmjs.com/package/@camunda/e2e-test-suite) npm package: login, human-task flow, connectors, and API tests against the basic-auth lightweight stack |
 
 Version-specific test directories are used when `e2e-test-directory` is specified in the CI matrix (see `.github/workflows/docker-compose-test-e2e-full-setup.yaml`).
+
+### Lightweight suite notes
+
+- The specs live inside the npm package (`node_modules/@camunda/e2e-test-suite/dist/tests/c8Run-8.X`); this repo only pins the package version and provides `playwright.config.ts` plus a checked-in `.env` with the stack's URLs.
+- The package resolves BPMN fixtures relative to the working directory, so `postinstall` symlinks `resources -> node_modules/@camunda/e2e-test-suite/resources` (the symlink is gitignored).
+- `zeebe-node` must stay an explicit devDependency: the package requires it at runtime but does not declare it as a dependency.
+- The `.env` sets `PLAYWRIGHT_BASE_URL` per version (8.8 publishes the orchestration REST API on host port `8088`, 8.9/8.10 on `8080`) and `DATABASE` (`ES` for 8.8, `RDBMS` for 8.9/8.10) which some specs use to self-skip.
 
 ## Running Locally
 
@@ -40,6 +48,26 @@ npx playwright install --with-deps chromium
 npx playwright test
 ```
 
+To test a lightweight stack with the shared cross-component suite:
+
+```bash
+cd docker-compose/versions/camunda-8.10
+docker compose up -d --wait --wait-timeout 300
+
+cd tests-lightweight
+npm ci
+npx playwright install --with-deps chromium
+npx playwright test
+```
+
+To test the 8.10 full stack locally, bring up the throwaway Elasticsearch first:
+
+```bash
+cd docker-compose/versions/camunda-8.10
+docker compose -f tests/docker-compose.elasticsearch-ci.yaml up -d
+docker compose -f docker-compose-full.yaml up -d --wait --wait-timeout 300
+```
+
 To run the focused Camunda 8.10 Keycloak and Web Modeler flow used in CI:
 
 ```bash
@@ -60,7 +88,10 @@ npx playwright test web_modeler_login.spec.ts
 - **Workers**: 1 (no parallel execution) in CI.
 - **Reports**: HTML artifacts uploaded with 30-day retention.
 - **Test gate**: Only versions with `e2e-test-enabled: true` in the matrix actually run Playwright. Others only validate that compose starts and becomes healthy.
-- **8.10 coverage**: The standalone Web Modeler job runs `web_modeler_login.spec.ts`, covering Keycloak startup, Identity realm initialization, and the browser OIDC callback without requiring external Elasticsearch.
+- **Lightweight jobs (8.8–8.10)**: run the `c8Run-8.X` suite from `@camunda/e2e-test-suite` against `docker-compose.yaml` with a 45-minute timeout (the connectors webhook spec waits 5 minutes synchronously).
+- **8.10 full-stack job**: brings up `tests/docker-compose.elasticsearch-ci.yaml` via the template's `deps-compose-args` before `docker-compose-full.yaml`, then runs every spec in `tests/` (`web_modeler_login.spec.ts` works there too — the hub service publishes host port `8070` in the full stack, same as the standalone setup).
+- **Shared CI file changes** (the two e2e workflows or anything under `.github/actions/`) reset the changed-versions filter so the whole matrix runs, and the merge gate treats them as e2e-relevant — a CI-only PR cannot go green without executing tests.
+- **8.10 Web Modeler standalone job**: runs `web_modeler_login.spec.ts`, covering Keycloak startup, Identity realm initialization, and the browser OIDC callback without requiring external Elasticsearch.
 
 ## Adding Tests for a New Version
 


### PR DESCRIPTION
### Which problem does the PR fix?

Part of #515.

### What's in this PR?

- `docs/e2e-testing.md`: test-layout table covering the new per-version `tests-lightweight/` packages and full-stack spec set, lightweight suite notes (resources symlink, `zeebe-node` pin, per-version `.env`), local run instructions for the lightweight stack and the 8.10 full stack with the CI-only Elasticsearch, and updated CI-configuration notes.
- `docs/ci-workflows.md`: matrix entry fields (`deps-compose-args`, `timeout-minutes`), the `tests-lightweight/` split, and the shared-CI-changes full-matrix behavior.

Documents the changes from #516, #517, #518, #519.