### PR TITLE
refactor(docker-compose): mount 8.10 application configuration

### DIFF
--- a/docker-compose/versions/camunda-8.10/.connectors/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.connectors/application.yaml
@@ -10,7 +10,7 @@ camunda:
       method: oidc
       issuer-url: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform"
       client-id: "${CONNECTORS_CLIENT_ID:connectors}"
-      client-secret: "${CONNECTORS_CLIENT_SECRET:demo-connectors-secret}"
+      client-secret: "${CONNECTORS_CLIENT_SECRET}"
       credentialsCachePath: /tmp/orchestration_auth_cache
       audience: orchestration-api
   connector:

--- a/docker-compose/versions/camunda-8.10/.connectors/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.connectors/application.yaml
@@ -4,8 +4,13 @@
 camunda:
   client:
     mode: self-managed
+    rest-address: http://orchestration:8080
+    grpc-address: http://orchestration:26500
     auth:
       method: oidc
+      issuer-url: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform"
+      client-id: "${CONNECTORS_CLIENT_ID:connectors}"
+      client-secret: "${CONNECTORS_CLIENT_SECRET:demo-connectors-secret}"
       credentialsCachePath: /tmp/orchestration_auth_cache
       audience: orchestration-api
   connector:

--- a/docker-compose/versions/camunda-8.10/.env
+++ b/docker-compose/versions/camunda-8.10/.env
@@ -22,7 +22,7 @@ KEYCLOAK_SERVER_VERSION=quay-26.6.4
 MAILPIT_VERSION=v1.21.8
 POSTGRES_VERSION=15-alpine3.22
 
-# Camunda Run configuration file to mount into the orchestration container
+# Lightweight Orchestration configuration file to mount into the container
 ORCHESTRATION_CONFIG_FILE=application-h2.yaml
 
 ## Network Configuration ##
@@ -87,10 +87,9 @@ RESOURCE_AUTHORIZATIONS_ENABLED=true
 
 ## Document Store Configuration (Optional) ##
 # Uncomment and configure if using external document storage.
-# Default stack: forward these into each service's environment section
-# (orchestration also accepts application.yaml; connectors reads env vars only).
-# Full stack: orchestration picks these up automatically via env_file; connectors
-# still needs manual forwarding via its environment section.
+# Both stacks forward .env to Orchestration and Connectors. Their application
+# defaults come from mounted YAML, while document-store credentials and provider
+# settings remain environment-driven.
 # DOCUMENT_DEFAULT_STORE_ID=...
 # AWS_ACCESS_KEY_ID=...
 # AWS_SECRET_ACCESS_KEY=...

--- a/docker-compose/versions/camunda-8.10/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.identity/application.yaml
@@ -62,7 +62,7 @@ identity:
         - name: Orchestration
           id: orchestration
           type: confidential
-          secret: "${ORCHESTRATION_CLIENT_SECRET:secret}"
+          secret: "${ORCHESTRATION_CLIENT_SECRET}"
           root-url: "http://localhost:8080"
           redirect-uris:
             - "/sso-callback"
@@ -162,7 +162,7 @@ keycloak:
     console:
       secret: "${CONSOLE_CLIENT_SECRET:demo-console-secret}"
     orchestration:
-      secret: "${ORCHESTRATION_CLIENT_SECRET:secret}"
+      secret: "${ORCHESTRATION_CLIENT_SECRET}"
     optimize:
       secret: "${OPTIMIZE_CLIENT_SECRET:demo-optimize-secret}"
     connectors:

--- a/docker-compose/versions/camunda-8.10/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.identity/application.yaml
@@ -157,7 +157,7 @@ keycloak:
   url: "http://${KEYCLOAK_HOST}:18080/auth"
   setup:
     user: "${KEYCLOAK_ADMIN_USER:admin}"
-    password: "${KEYCLOAK_ADMIN_PASSWORD:admin}"
+    password: "${KEYCLOAK_ADMIN_PASSWORD}"
   init:
     console:
       secret: "${CONSOLE_CLIENT_SECRET}"

--- a/docker-compose/versions/camunda-8.10/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.identity/application.yaml
@@ -14,7 +14,7 @@ identity:
         - name: Connectors
           id: connectors
           type: m2m
-          secret: "${CONNECTORS_CLIENT_SECRET:demo-connectors-secret}"
+          secret: "${CONNECTORS_CLIENT_SECRET}"
           permissions:
             - audience: "orchestration-api"
               definition: read:*
@@ -87,7 +87,7 @@ identity:
         - name: Optimize
           id: optimize
           type: confidential
-          secret: "${OPTIMIZE_CLIENT_SECRET:demo-optimize-secret}"
+          secret: "${OPTIMIZE_CLIENT_SECRET}"
           root-url: "http://localhost:8083"
           redirect-uris:
             - "/api/authentication/callback"
@@ -160,13 +160,13 @@ keycloak:
     password: "${KEYCLOAK_ADMIN_PASSWORD:admin}"
   init:
     console:
-      secret: "${CONSOLE_CLIENT_SECRET:demo-console-secret}"
+      secret: "${CONSOLE_CLIENT_SECRET}"
     orchestration:
       secret: "${ORCHESTRATION_CLIENT_SECRET}"
     optimize:
-      secret: "${OPTIMIZE_CLIENT_SECRET:demo-optimize-secret}"
+      secret: "${OPTIMIZE_CLIENT_SECRET}"
     connectors:
-      secret: "${CONNECTORS_CLIENT_SECRET:demo-connectors-secret}"
+      secret: "${CONNECTORS_CLIENT_SECRET}"
     webmodeler:
       root-url: "http://localhost:8070"
   clients:
@@ -204,7 +204,7 @@ spring:
   datasource:
     url: "jdbc:postgresql://postgres:5432/${POSTGRES_DB:keycloak}"
     username: "${POSTGRES_USER:keycloak}"
-    password: "${POSTGRES_PASSWORD:demo-postgres-password}"
+    password: "${POSTGRES_PASSWORD}"
 
 management:
   endpoints:

--- a/docker-compose/versions/camunda-8.10/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.identity/application.yaml
@@ -2,6 +2,7 @@ identity:
   url: "http://localhost:8084"
   flags:
     multi-tenancy: "false"
+    resource-permissions: "${RESOURCE_AUTHORIZATIONS_ENABLED:true}"
 
   authProvider:
     issuer-url: "http://${HOST}:18080/auth/realms/camunda-platform"
@@ -13,7 +14,7 @@ identity:
         - name: Connectors
           id: connectors
           type: m2m
-          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:demo-connectors-secret}
+          secret: "${CONNECTORS_CLIENT_SECRET:demo-connectors-secret}"
           permissions:
             - audience: "orchestration-api"
               definition: read:*
@@ -61,7 +62,7 @@ identity:
         - name: Orchestration
           id: orchestration
           type: confidential
-          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:secret}
+          secret: "${ORCHESTRATION_CLIENT_SECRET:secret}"
           root-url: "http://localhost:8080"
           redirect-uris:
             - "/sso-callback"
@@ -86,7 +87,7 @@ identity:
         - name: Optimize
           id: optimize
           type: confidential
-          secret: ${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:demo-optimize-secret}
+          secret: "${OPTIMIZE_CLIENT_SECRET:demo-optimize-secret}"
           root-url: "http://localhost:8083"
           redirect-uris:
             - "/api/authentication/callback"
@@ -159,13 +160,13 @@ keycloak:
     password: "${KEYCLOAK_ADMIN_PASSWORD:admin}"
   init:
     console:
-      secret: ${VALUES_KEYCLOAK_INIT_CONSOLE_SECRET:demo-console-secret}
+      secret: "${CONSOLE_CLIENT_SECRET:demo-console-secret}"
     orchestration:
-      secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:secret}
+      secret: "${ORCHESTRATION_CLIENT_SECRET:secret}"
     optimize:
-      secret: ${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:demo-optimize-secret}
+      secret: "${OPTIMIZE_CLIENT_SECRET:demo-optimize-secret}"
     connectors:
-      secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:demo-connectors-secret}
+      secret: "${CONNECTORS_CLIENT_SECRET:demo-connectors-secret}"
     webmodeler:
       root-url: "http://localhost:8070"
   clients:
@@ -196,8 +197,26 @@ server:
   port: 8084
 
 spring:
+  config:
+    import: optional:file:/app/config/application-web-modeler.yaml
   profiles:
     active: keycloak
+  datasource:
+    url: "jdbc:postgresql://postgres:5432/${POSTGRES_DB:keycloak}"
+    username: "${POSTGRES_USER:keycloak}"
+    password: "${POSTGRES_PASSWORD:demo-postgres-password}"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,configprops
+  endpoint:
+    configprops:
+      show-values: ALWAYS
+    health:
+      probes:
+        enabled: true
 
 camunda:
   identity:

--- a/docker-compose/versions/camunda-8.10/.optimize/application-ccsm.yaml
+++ b/docker-compose/versions/camunda-8.10/.optimize/application-ccsm.yaml
@@ -3,7 +3,7 @@ camunda:
     issuer: "http://${HOST:localhost}:18080/auth/realms/camunda-platform"
     issuerBackendUrl: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform"
     clientId: optimize
-    clientSecret: "${OPTIMIZE_CLIENT_SECRET:demo-optimize-secret}"
+    clientSecret: "${OPTIMIZE_CLIENT_SECRET}"
     audience: optimize-api
     baseUrl: http://identity:8084
 

--- a/docker-compose/versions/camunda-8.10/.optimize/application-ccsm.yaml
+++ b/docker-compose/versions/camunda-8.10/.optimize/application-ccsm.yaml
@@ -1,0 +1,20 @@
+camunda:
+  identity:
+    issuer: "http://${HOST:localhost}:18080/auth/realms/camunda-platform"
+    issuerBackendUrl: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform"
+    clientId: optimize
+    clientSecret: "${OPTIMIZE_CLIENT_SECRET:demo-optimize-secret}"
+    audience: optimize-api
+    baseUrl: http://identity:8084
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,configprops
+  endpoint:
+    configprops:
+      show-values: ALWAYS
+    health:
+      probes:
+        enabled: true

--- a/docker-compose/versions/camunda-8.10/.optimize/environment-config.yaml
+++ b/docker-compose/versions/camunda-8.10/.optimize/environment-config.yaml
@@ -1,4 +1,8 @@
 es:
+  connection:
+    nodes:
+      - host: "${ELASTICSEARCH_HOST:host.docker.internal}"
+        httpPort: "${ELASTICSEARCH_PORT:9200}"
   settings:
     index:
       number_of_replicas: 0

--- a/docker-compose/versions/camunda-8.10/.orchestration/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.orchestration/application.yaml
@@ -97,7 +97,7 @@ camunda:
       unprotectedApi: false
       oidc:
         client-id: "${ORCHESTRATION_CLIENT_ID:orchestration}"
-        client-secret: "${ORCHESTRATION_CLIENT_SECRET:secret}"
+        client-secret: "${ORCHESTRATION_CLIENT_SECRET}"
         audiences:
           - orchestration
           - orchestration-api

--- a/docker-compose/versions/camunda-8.10/.orchestration/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.orchestration/application.yaml
@@ -29,6 +29,10 @@ zeebe:
       network:
         host: 0.0.0.0
         port: 26500
+      security:
+        authentication:
+          identity:
+            issuerBackendUrl: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform"
 
     # zeebe.broker.network
     network:
@@ -82,10 +86,28 @@ camunda:
   mcp:
     enabled: true
 
+  identity:
+    issuer-backend-url: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform"
+    base-url: http://identity:8084
+    audience: orchestration-api
+
   security:
     authentication:
       method: "oidc"
       unprotectedApi: false
+      oidc:
+        client-id: "${ORCHESTRATION_CLIENT_ID:orchestration}"
+        client-secret: "${ORCHESTRATION_CLIENT_SECRET:secret}"
+        audiences:
+          - orchestration
+          - orchestration-api
+          - web-modeler-api
+        authorization-uri: "http://${HOST:localhost}:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+        token-uri: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+        jwk-set-uri: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+        redirect-uri: "http://${HOST:localhost}:8080/sso-callback"
+        username-claim: preferred_username
+        client-id-claim: client_id
     authorizations:
       enabled: true
     initialization:

--- a/docker-compose/versions/camunda-8.10/.web-modeler/application-full.yaml
+++ b/docker-compose/versions/camunda-8.10/.web-modeler/application-full.yaml
@@ -1,0 +1,78 @@
+spring:
+  config:
+    import: file:/home/runner/config/application-common.yaml
+
+camunda:
+  modeler:
+    clusters:
+      - id: management
+        name: management
+        version: "${CAMUNDA_WEB_MODELER_VERSION:8.10}"
+        tags:
+          - dev
+          - local
+        authentication: BEARER_TOKEN
+        authorizations:
+          enabled: "${RESOURCE_AUTHORIZATIONS_ENABLED:true}"
+        namespace: management
+        components:
+          - name: Identity
+            type: identity
+            version: "${CAMUNDA_IDENTITY_VERSION:8.9}"
+            urls:
+              webapp: http://localhost:8084
+              readiness: http://identity:8082/actuator/health
+          - name: WebModeler
+            type: webModelerWebApp
+            version: "${CAMUNDA_WEB_MODELER_VERSION:8.10}"
+            urls:
+              webapp: http://localhost:8070
+              readiness: http://hub:8091/health/readiness
+      - id: camunda-platform
+        name: camunda-platform
+        version: "${CAMUNDA_VERSION:8.10}"
+        tags:
+          - dev
+          - local
+        authentication: BEARER_TOKEN
+        authorizations:
+          enabled: "${RESOURCE_AUTHORIZATIONS_ENABLED:true}"
+        namespace: camunda-platform
+        components:
+          - name: Orchestration
+            type: orchestration
+            version: "${CAMUNDA_VERSION:8.10}"
+            urls:
+              grpc: grpc://orchestration:26500
+              rest: http://orchestration:8080
+              readiness: http://orchestration:9600/actuator/health/status
+          - name: Operate
+            type: operate
+            version: "${CAMUNDA_VERSION:8.10}"
+            urls:
+              webapp: http://localhost:8080/operate
+              readiness: http://orchestration:9600/actuator/health/readiness
+          - name: Tasklist
+            type: tasklist
+            version: "${CAMUNDA_VERSION:8.10}"
+            urls:
+              webapp: http://localhost:8080/tasklist
+              readiness: http://orchestration:9600/actuator/health/readiness
+          - name: Optimize
+            type: optimize
+            version: "${CAMUNDA_OPTIMIZE_VERSION:8.10}"
+            urls:
+              webapp: http://localhost:8083
+              readiness: http://optimize:8090/api/readyz
+          - name: Connectors
+            type: connectors
+            version: "${CAMUNDA_CONNECTORS_VERSION:8.10}"
+            urls:
+              rest: http://connectors:8080
+              readiness: http://connectors:8080/actuator/health/readiness
+          - name: Admin
+            type: orchestrationIdentity
+            version: "${CAMUNDA_VERSION:8.10}"
+            urls:
+              webapp: http://localhost:8080/admin
+              readiness: http://orchestration:9600/actuator/health/readiness

--- a/docker-compose/versions/camunda-8.10/.web-modeler/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.web-modeler/application.yaml
@@ -1,0 +1,66 @@
+camunda:
+  identity:
+    base-url: http://identity:8084/
+    issuer: "http://${HOST:localhost}:18080/auth/realms/camunda-platform"
+    issuerBackendUrl: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform"
+    type: KEYCLOAK
+  modeler:
+    feature:
+      play-enabled: true
+    pusher:
+      host: hub-websockets
+      port: 8060
+      client:
+        host: localhost
+        port: 8060
+        force-tls: false
+    security:
+      jwt:
+        issuer:
+          backend-url: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform"
+        audience:
+          internal-api: web-modeler-api
+          public-api: web-modeler-public-api
+    mail:
+      from-address: "${WEBMODELER_MAIL_FROM_ADDRESS:noreply@camunda.example.com}"
+    oauth2:
+      client-id: web-modeler
+    server:
+      url: http://localhost:8070
+      https-only: false
+
+spring:
+  profiles:
+    include: default-logging
+  datasource:
+    url: "jdbc:postgresql://web-modeler-db:5432/${WEBMODELER_DB_NAME:web-modeler-db}"
+    username: "${WEBMODELER_DB_USER:web-modeler-db-user}"
+  mail:
+    host: mailpit
+    port: 1025
+    properties:
+      mail.smtp.auth: false
+      mail.smtp.starttls.enable: false
+      mail.smtp.starttls.required: false
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: "http://${HOST:localhost}:18080/auth/realms/camunda-platform"
+          jwk-set-uri: "http://${KEYCLOAK_HOST:host.docker.internal}:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,configprops,info
+  endpoint:
+    configprops:
+      show-values: ALWAYS
+    health:
+      probes:
+        enabled: true
+
+logging:
+  level:
+    io.camunda.modeler: DEBUG

--- a/docker-compose/versions/camunda-8.10/README.md
+++ b/docker-compose/versions/camunda-8.10/README.md
@@ -4,6 +4,16 @@
 
 For end user usage, please check the official documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/docker-compose/).
 
+## Application configuration
+
+Camunda services read their application settings from YAML mounted by Docker Compose:
+
+- The lightweight `docker-compose.yaml` keeps its Connectors YAML inline under `configs`, preserving the compact setup. Orchestration mounts the selected file from `configuration/`.
+- The full and standalone setups share component files under `.identity/` and `.web-modeler/`. The standalone-only Identity overlay remains inline in `docker-compose-web-modeler.yaml`.
+- The full setup additionally uses `.orchestration/application.yaml`, `.connectors/application.yaml`, and the files under `.optimize/`. Hub cluster registrations are isolated in `.web-modeler/application-full.yaml`.
+
+The mounted files reference runtime values from `.env` with `${VARIABLE:default}` placeholders. Keep environment-specific endpoints and secrets in `.env`; direct Spring environment variables can still override file values. Hub database and Pusher credentials remain direct environment variables, matching the Helm deployment. PostgreSQL, Keycloak, Hub WebSockets, and other non-Spring services continue to use their native environment-based configuration.
+
 ## Elasticsearch
 
 Camunda `8.10` no longer bundles Elasticsearch in Docker Compose.

--- a/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-full.yaml
@@ -26,25 +26,7 @@ services:
       - "26500:26500"
       - "9600:9600"
       - "8080:8080"
-    environment: # https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/environment-variables/
-      # OIDC Authentication - Environment-specific URLs and secrets
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_CLIENTID: ${ORCHESTRATION_CLIENT_ID}
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_CLIENTSECRET: ${ORCHESTRATION_CLIENT_SECRET}
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_AUDIENCES_0: orchestration
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_AUDIENCES_1: orchestration-api
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_AUDIENCES_2: web-modeler-api
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_AUTHORIZATIONURI: http://${HOST}:18080/auth/realms/camunda-platform/protocol/openid-connect/auth
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_TOKENURI: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_JWKSETURI: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_REDIRECTURI: http://${HOST}:8080/sso-callback
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_USERNAMECLAIM: preferred_username
-      CAMUNDA_SECURITY_AUTHENTICATION_OIDC_CLIENTIDCLAIM: client_id
-      ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
-      # Identity integration
-      CAMUNDA_IDENTITY_ISSUERBACKENDURL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
-      CAMUNDA_IDENTITY_BASEURL: http://identity:8084
-      CAMUNDA_IDENTITY_AUDIENCE: orchestration-api
-      # Resource limits
+    environment:
       JAVA_TOOL_OPTIONS: "-Xms512m -Xmx512m"
     env_file:
       - path: .env
@@ -73,13 +55,6 @@ services:
     container_name: connectors
     ports:
       - "8086:8080"
-    environment:
-      # Orchestration connection - service addresses and credentials
-      CAMUNDA_CLIENT_RESTADDRESS: http://orchestration:8080
-      CAMUNDA_CLIENT_GRPCADDRESS: http://orchestration:26500
-      CAMUNDA_CLIENT_AUTH_ISSUERURL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
-      CAMUNDA_CLIENT_AUTH_CLIENTID: ${CONNECTORS_CLIENT_ID}
-      CAMUNDA_CLIENT_AUTH_CLIENTSECRET: ${CONNECTORS_CLIENT_SECRET}
     env_file:
       - connector-secrets.txt
       - path: .env
@@ -106,22 +81,11 @@ services:
     container_name: optimize
     ports:
       - "8083:8090"
-    environment: # https://docs.camunda.io/docs/self-managed/optimize-deployment/install-and-start/
-      # Elasticsearch connection
-      OPTIMIZE_ELASTICSEARCH_HOST: ${ELASTICSEARCH_HOST}
-      OPTIMIZE_ELASTICSEARCH_HTTP_PORT: "${ELASTICSEARCH_PORT}"
+    environment:
       SPRING_PROFILES_ACTIVE: ccsm
-      # Identity integration - URLs and credentials
-      CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL: http://${HOST}:18080/auth/realms/camunda-platform
-      CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
-      CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID: optimize
-      CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET: ${OPTIMIZE_CLIENT_SECRET}
-      CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE: optimize-api
-      CAMUNDA_OPTIMIZE_IDENTITY_BASE_URL: http://identity:8084
-      # Management endpoints
-      management.endpoints.web.exposure.include: health,configprops
-      MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
-      management.endpoint.health.probes.enabled: "true"
+    env_file:
+      - path: .env
+        required: true
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8090/api/readyz"]
       interval: 30s
@@ -130,6 +94,7 @@ services:
       start_period: 30s
     volumes:
       - "./.optimize/environment-config.yaml:/optimize/config/environment-config.yaml"
+      - "./.optimize/application-ccsm.yaml:/optimize/config/application-ccsm.yaml"
     restart: on-failure
     networks:
       - camunda-platform
@@ -144,23 +109,9 @@ services:
     image: camunda/identity:${CAMUNDA_IDENTITY_VERSION}
     ports:
       - "8084:8084"
-    environment: # https://docs.camunda.io/docs/self-managed/identity/miscellaneous/configuration-variables/
-      IDENTITY_DATABASE_HOST: postgres
-      IDENTITY_DATABASE_PORT: 5432
-      IDENTITY_DATABASE_NAME: ${POSTGRES_DB}
-      IDENTITY_DATABASE_USERNAME: ${POSTGRES_USER}
-      IDENTITY_DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
-      VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET: ${ORCHESTRATION_CLIENT_SECRET}
-      VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET: ${OPTIMIZE_CLIENT_SECRET}
-      VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET: ${CONNECTORS_CLIENT_SECRET}
-      KEYCLOAK_ADMIN_USER: ${KEYCLOAK_ADMIN_USER}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
-      HOST: ${HOST}
-      KEYCLOAK_HOST: ${KEYCLOAK_HOST}
-      RESOURCE_PERMISSIONS_ENABLED: ${RESOURCE_AUTHORIZATIONS_ENABLED}
-      management.endpoints.web.exposure.include: health,configprops
-      management.endpoint.health.probes.enabled: true
-      MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
+    env_file:
+      - path: .env
+        required: true
     healthcheck:
       test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:8082/actuator/health"]
       interval: 5s
@@ -306,91 +257,16 @@ services:
       start_period: 60s
     environment:
       JAVA_OPTIONS: -Xmx512m
-      LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
-      CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
-      SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/${WEBMODELER_DB_NAME}
-      SPRING_DATASOURCE_USERNAME: ${WEBMODELER_DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${WEBMODELER_DB_PASSWORD}
-      SPRING_PROFILES_INCLUDE: default-logging
-      RESTAPI_PUSHER_HOST: hub-websockets
-      RESTAPI_PUSHER_PORT: "8060"
       RESTAPI_PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}
       RESTAPI_PUSHER_KEY: ${WEBMODELER_PUSHER_KEY}
       RESTAPI_PUSHER_SECRET: ${WEBMODELER_PUSHER_SECRET}
-      RESTAPI_OAUTH2_TOKEN_ISSUER: http://${HOST}:18080/auth/realms/camunda-platform
-      RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
-      RESTAPI_SERVER_URL: http://localhost:8070
-      RESTAPI_MAIL_HOST: mailpit
-      RESTAPI_MAIL_PORT: 1025
-      RESTAPI_MAIL_ENABLE_TLS: "false"
-      RESTAPI_MAIL_FROM_ADDRESS: ${WEBMODELER_MAIL_FROM_ADDRESS}
-      CAMUNDA_MODELER_CLUSTERS_0_ID: "management"
-      CAMUNDA_MODELER_CLUSTERS_0_NAME: "management"
-      CAMUNDA_MODELER_CLUSTERS_0_VERSION: ${CAMUNDA_WEB_MODELER_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_0_TAGS_0: "dev"
-      CAMUNDA_MODELER_CLUSTERS_0_TAGS_1: "local"
-      CAMUNDA_MODELER_CLUSTERS_0_AUTHENTICATION: BEARER_TOKEN
-      CAMUNDA_MODELER_CLUSTERS_0_AUTHORIZATIONS_ENABLED: ${RESOURCE_AUTHORIZATIONS_ENABLED}
-      CAMUNDA_MODELER_CLUSTERS_0_NAMESPACE: "management"
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_0_NAME: "Identity"
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_0_TYPE: "identity"
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_0_VERSION: ${CAMUNDA_IDENTITY_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_0_URLS_WEBAPP: "http://localhost:8084"
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_0_URLS_READINESS: "http://identity:8082/actuator/health"
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_NAME: "WebModeler"
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_TYPE: "webModelerWebApp"
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_VERSION: ${CAMUNDA_WEB_MODELER_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_URLS_WEBAPP: "http://localhost:8070"
-      CAMUNDA_MODELER_CLUSTERS_0_COMPONENTS_1_URLS_READINESS: "http://hub:8091/health/readiness"
-      CAMUNDA_MODELER_CLUSTERS_1_ID: "camunda-platform"
-      CAMUNDA_MODELER_CLUSTERS_1_NAME: "camunda-platform"
-      CAMUNDA_MODELER_CLUSTERS_1_VERSION: ${CAMUNDA_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_1_TAGS_0: "dev"
-      CAMUNDA_MODELER_CLUSTERS_1_TAGS_1: "local"
-      CAMUNDA_MODELER_CLUSTERS_1_AUTHENTICATION: BEARER_TOKEN
-      CAMUNDA_MODELER_CLUSTERS_1_AUTHORIZATIONS_ENABLED: ${RESOURCE_AUTHORIZATIONS_ENABLED}
-      CAMUNDA_MODELER_CLUSTERS_1_NAMESPACE: "camunda-platform"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_0_NAME: "Orchestration"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_0_TYPE: "orchestration"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_0_VERSION: ${CAMUNDA_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_0_URLS_GRPC: "grpc://orchestration:26500"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_0_URLS_REST: "http://orchestration:8080"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_0_URLS_READINESS: "http://orchestration:9600/actuator/health/status"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_1_NAME: "Operate"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_1_TYPE: "operate"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_1_VERSION: ${CAMUNDA_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_1_URLS_WEBAPP: "http://localhost:8080/operate"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_1_URLS_READINESS: "http://orchestration:9600/actuator/health/readiness"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_2_NAME: "Tasklist"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_2_TYPE: "tasklist"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_2_VERSION: ${CAMUNDA_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_2_URLS_WEBAPP: "http://localhost:8080/tasklist"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_2_URLS_READINESS: "http://orchestration:9600/actuator/health/readiness"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_3_NAME: "Optimize"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_3_TYPE: "optimize"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_3_VERSION: ${CAMUNDA_OPTIMIZE_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_3_URLS_WEBAPP: "http://localhost:8083"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_3_URLS_READINESS: "http://optimize:8090/api/readyz"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_4_NAME: "Connectors"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_4_TYPE: "connectors"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_4_VERSION: ${CAMUNDA_CONNECTORS_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_4_URLS_REST: "http://connectors:8080"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_4_URLS_READINESS: "http://connectors:8080/actuator/health/readiness"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_5_NAME: "Admin"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_5_TYPE: orchestrationIdentity
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_5_VERSION: ${CAMUNDA_VERSION}
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_5_URLS_WEBAPP: "http://localhost:8080/admin"
-      CAMUNDA_MODELER_CLUSTERS_1_COMPONENTS_5_URLS_READINESS: "http://orchestration:9600/actuator/health/readiness"
-      management.endpoints.web.exposure.include: health,configprops,info
-      management.endpoint.health.probes.enabled: true
-      MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
-      CAMUNDA_MODELER_SECURITY_JWT_AUDIENCE_INTERNAL_API: web-modeler-api
-      SERVER_HTTPS_ONLY: "false"
-      CLIENT_PUSHER_HOST: localhost
-      CLIENT_PUSHER_PORT: "8060"
-      CLIENT_PUSHER_FORCE_TLS: "false"
-      OAUTH2_CLIENT_ID: web-modeler
-      PLAY_ENABLED: "true"
+    env_file:
+      - path: .env
+        required: true
+    volumes:
+      - "./.web-modeler/application.yaml:/home/runner/config/application-common.yaml:ro"
+      - "./.web-modeler/application-full.yaml:/home/runner/config/application.yaml:ro"
     networks:
       - web-modeler
       - camunda-platform

--- a/docker-compose/versions/camunda-8.10/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-web-modeler.yaml
@@ -91,34 +91,15 @@ services:
       start_period: 60s
     environment:
       JAVA_OPTIONS: -Xmx512m
-      LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
-      CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
-      SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/${WEBMODELER_DB_NAME}
-      SPRING_DATASOURCE_USERNAME: ${WEBMODELER_DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${WEBMODELER_DB_PASSWORD}
-      SPRING_PROFILES_INCLUDE: default-logging
-      RESTAPI_PUSHER_HOST: hub-websockets
-      RESTAPI_PUSHER_PORT: "8060"
       RESTAPI_PUSHER_APP_ID: ${WEBMODELER_PUSHER_APP_ID}
       RESTAPI_PUSHER_KEY: ${WEBMODELER_PUSHER_KEY}
       RESTAPI_PUSHER_SECRET: ${WEBMODELER_PUSHER_SECRET}
-      RESTAPI_OAUTH2_TOKEN_ISSUER: http://${HOST}:18080/auth/realms/camunda-platform
-      RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
-      RESTAPI_SERVER_URL: http://localhost:8070
-      RESTAPI_MAIL_HOST: mailpit
-      RESTAPI_MAIL_PORT: 1025
-      RESTAPI_MAIL_ENABLE_TLS: "false"
-      RESTAPI_MAIL_FROM_ADDRESS: ${WEBMODELER_MAIL_FROM_ADDRESS}
-      management.endpoints.web.exposure.include: health,configprops,info
-      management.endpoint.health.probes.enabled: true
-      MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
-      CAMUNDA_MODELER_SECURITY_JWT_AUDIENCE_INTERNAL_API: web-modeler-api
-      SERVER_HTTPS_ONLY: "false"
-      CLIENT_PUSHER_HOST: localhost
-      CLIENT_PUSHER_PORT: "8060"
-      CLIENT_PUSHER_FORCE_TLS: "false"
-      OAUTH2_CLIENT_ID: web-modeler
-      PLAY_ENABLED: "true"
+    env_file:
+      - path: .env
+        required: true
+    volumes:
+      - "./.web-modeler/application.yaml:/home/runner/config/application.yaml:ro"
     networks:
       - web-modeler
       - camunda-platform
@@ -130,25 +111,9 @@ services:
     image: camunda/identity:${CAMUNDA_IDENTITY_VERSION}
     ports:
       - "8084:8084"
-    environment: # https://docs.camunda.io/docs/self-managed/identity/miscellaneous/configuration-variables/
-      IDENTITY_DATABASE_HOST: postgres
-      IDENTITY_DATABASE_PORT: 5432
-      IDENTITY_DATABASE_NAME: ${POSTGRES_DB}
-      IDENTITY_DATABASE_USERNAME: ${POSTGRES_USER}
-      IDENTITY_DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
-      KEYCLOAK_ADMIN_USER: ${KEYCLOAK_ADMIN_USER}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
-      HOST: ${HOST}
-      KEYCLOAK_HOST: ${KEYCLOAK_HOST}
-      # Orchestration client (for Web Modeler to deploy to orchestration if available)
-      KEYCLOAK_CLIENTS_0_NAME: "orchestration"
-      KEYCLOAK_CLIENTS_0_ID: ${ORCHESTRATION_CLIENT_ID}
-      KEYCLOAK_CLIENTS_0_SECRET: ${ORCHESTRATION_CLIENT_SECRET}
-      KEYCLOAK_CLIENTS_0_TYPE: "M2M"
-      RESOURCE_PERMISSIONS_ENABLED: ${RESOURCE_AUTHORIZATIONS_ENABLED}
-      management.endpoints.web.exposure.include: health,configprops
-      management.endpoint.health.probes.enabled: true
-      MANAGEMENT_ENDPOINT_CONFIGPROPS_SHOW_VALUES: ALWAYS
+    env_file:
+      - path: .env
+        required: true
     healthcheck:
       test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:8082/actuator/health"]
       interval: 5s
@@ -158,6 +123,9 @@ services:
     restart: on-failure
     volumes:
       - "./.identity/application.yaml:/app/application.yaml"
+    configs:
+      - source: identity-web-modeler-config
+        target: /app/config/application-web-modeler.yaml
     networks:
       - camunda-platform
       - identity-network
@@ -241,3 +209,13 @@ networks:
 volumes:
   postgres:
   postgres-web:
+
+configs:
+  identity-web-modeler-config:
+    content: |
+      keycloak:
+        clients:
+          - name: orchestration
+            id: "$${ORCHESTRATION_CLIENT_ID:orchestration}"
+            secret: "$${ORCHESTRATION_CLIENT_SECRET:secret}"
+            type: M2M

--- a/docker-compose/versions/camunda-8.10/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose-web-modeler.yaml
@@ -217,5 +217,5 @@ configs:
         clients:
           - name: orchestration
             id: "$${ORCHESTRATION_CLIENT_ID:orchestration}"
-            secret: "$${ORCHESTRATION_CLIENT_SECRET:secret}"
+            secret: "$${ORCHESTRATION_CLIENT_SECRET}"
             type: M2M

--- a/docker-compose/versions/camunda-8.10/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.10/docker-compose.yaml
@@ -57,9 +57,6 @@ services:
     container_name: connectors
     ports:
       - "8086:8080"
-    environment:
-      - management.endpoints.web.exposure.include=health,configprops
-      - management.endpoint.health.probes.enabled=true
     env_file:
       - connector-secrets.txt
       - path: .env
@@ -74,7 +71,7 @@ services:
       start_period: 30s
     configs:
       - source: connectors-config
-        target: application.yaml
+        target: /application.yaml
     networks:
       - camunda
     depends_on:
@@ -102,6 +99,15 @@ configs:
           secretprovider:
             environment:
               prefix: "CONNECTORS_SECRET"
+      management:
+        endpoints:
+          web:
+            exposure:
+              include: health,configprops
+        endpoint:
+          health:
+            probes:
+              enabled: true
 
   orchestration-config:
     file: ./configuration/${ORCHESTRATION_CONFIG_FILE:-application-h2.yaml}

--- a/docs/version-architecture.md
+++ b/docs/version-architecture.md
@@ -14,7 +14,7 @@ Each supported Camunda version lives in its own directory under `docker-compose/
 | 8.8–8.9 | Lightweight (Zeebe + Operate + Tasklist + Connectors, no Identity/Optimize) | Full stack | Standalone Web Modeler | — |
 | 8.10+   | Lightweight (H2 default, no ES) | Full stack (requires external ES) | Standalone Web Modeler | — |
 
-**Key shift at 8.8:** `docker-compose.yaml` became the lightweight setup. To get the full stack (Identity, Optimize, Web Modeler, Console), use `docker-compose-full.yaml`.
+**Key shift at 8.8:** `docker-compose.yaml` became the lightweight setup. Use `docker-compose-full.yaml` for Identity, Optimize, and Web Modeler. The 8.8–8.9 full stack also includes Console.
 
 ## Elasticsearch Changes at 8.10
 
@@ -53,16 +53,27 @@ docker-compose/versions/camunda-X.Y/
   docker-compose-web-modeler.yaml  # Web Modeler standalone
   .env                             # Image versions + runtime config (template, not for real secrets)
   connector-secrets.txt            # Connector environment variables
-  configuration/                   # Database-specific application.yaml files (8.10+)
+  configuration/                   # Selectable Orchestration application files (8.9+)
   driver-lib/                      # Drop vendor JDBC jars here (gitignored content)
   camunda-data/                    # Runtime H2 data (gitignored)
   tests/                           # Version-specific Playwright tests (8.8+)
-  .orchestration/application.yaml  # Zeebe/Operate/Tasklist config
-  .connectors/application.yaml     # Connectors bundle config
+  .orchestration/application.yaml  # Full-stack Orchestration config
+  .connectors/application.yaml     # Full-stack Connectors config
   .identity/application.yaml       # Identity/Keycloak config
-  .console/application.yaml        # Console config
-  .optimize/application.yaml       # Optimize config
+  .console/application.yaml        # Console config (8.8–8.9)
+  .optimize/environment-config.yaml # Optimize native config
+  .optimize/application-ccsm.yaml  # Optimize Identity config (8.10+)
+  .web-modeler/application.yaml    # Shared Hub config (8.10+)
+  .web-modeler/application-full.yaml # Full-stack Hub clusters (8.10+)
 ```
+
+## Application Configuration at 8.10
+
+- The lightweight setup remains compact: Connectors application YAML is inline under the top-level Compose `configs`, while Orchestration mounts the selected file from `configuration/`.
+- The full stack mounts the component files under `.orchestration/`, `.connectors/`, `.identity/`, `.optimize/`, and `.web-modeler/`.
+- Full and standalone Hub share `.web-modeler/application.yaml`. The full-stack `application-full.yaml` imports it and adds cluster registrations.
+- Standalone Web Modeler remains one Compose entry point. Its small standalone-only Identity client overlay is inline in `docker-compose-web-modeler.yaml` and imported by `.identity/application.yaml`.
+- `.env` provides runtime values and development secrets. Spring environment variables remain available as overrides, while PostgreSQL, Keycloak, Hub WebSockets, and other native services keep their environment-based configuration.
 
 ## Authentication
 


### PR DESCRIPTION
Closes #531

## Summary

- preserve the compact lightweight flow by keeping Connectors application YAML inline under Docker `configs`
- move full-stack Orchestration, Connectors, Identity, and Optimize defaults into their supported mounted files
- derive shared Hub REST configuration from the 8.10 Helm schema while keeping Hub WebSockets and credentials environment-driven
- preserve one-file-invocation standalone Hub and document the 8.10 configuration ownership model

## Validation

- `docker compose -f docker-compose.yaml config --quiet`
- `docker compose -f docker-compose-full.yaml config --quiet`
- `docker compose -f docker-compose-web-modeler.yaml config --quiet`
- structured YAML parsing for all changed YAML files
- `git diff --check`
- editor diagnostics: no errors

Runtime and Playwright coverage is intentionally delegated to PR CI. The required public `docs/next` update will be linked from #531.

Follow-up version PRs: #532 and #533.